### PR TITLE
MK: #65 Empty repeat group fixed and deployed

### DIFF
--- a/opensrp-connector/src/main/java/org/opensrp/connector/OpenmrsConnector.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/OpenmrsConnector.java
@@ -283,9 +283,15 @@ public class OpenmrsConnector {
 			Map<String, String> att = formAttributeMapper.getAttributesForSubform(sbf.name(), fs);
 			if(att.size() > 0 && att.get("openmrs_entity").equalsIgnoreCase("person")){
 				for (Map<String, String> sfdata : sbf.instances()) {
+					String firstName = sfdata.get(getFieldName(Person.first_name, sbf.name(), fs));
+					Map<String, String> idents = extractIdentifiers(sfdata, sbf.name(), fs);
+					if(StringUtils.isEmptyOrWhitespaceOnly(firstName)
+							&& idents.size() < 2){//we need to ignore uuid of entity
+						// if empty repeat group leave this entry and move to next
+						continue;
+					}
 					Map<String, Object> cne = new HashMap<>();
 					
-					String firstName = sfdata.get(getFieldName(Person.first_name, sbf.name(), fs));
 					String middleName = sfdata.get(getFieldName(Person.middle_name, sbf.name(), fs));
 					String lastName = sfdata.get(getFieldName(Person.last_name, sbf.name(), fs));
 					Date birthdate = OpenmrsService.OPENMRS_DATE.parse(sfdata.get(getFieldName(Person.birthdate, sbf.name(), fs)));
@@ -300,7 +306,7 @@ public class OpenmrsConnector {
 					Client c = new Client()
 					.withBaseEntity(new BaseEntity(sfdata.get("id"), firstName, middleName, lastName, birthdate, deathdate, 
 							birthdateApprox, deathdateApprox, gender, addresses, extractAttributes(sfdata, sbf.name(), fs)))
-					.withIdentifiers(extractIdentifiers(sfdata, sbf.name(), fs));
+					.withIdentifiers(idents);
 					
 					cne.put("client", c);
 					cne.put("event", getEventForSubform(fs, sbf.name(), att.get("openmrs_entity_id"), sfdata));

--- a/releaseNotes.txt
+++ b/releaseNotes.txt
@@ -1,19 +1,16 @@
-Date of Release: 23-Jun-2015
+Date of Release: 08-Jul-2015
 
 New Features
 ============
-- Added power mock api in pom to handle static class mocks
 
 Changes
 =======
-- Removed all calls to live server in connector tests and now using only mock objects and mock calls
-- Using mocks only instead of calls to server in opensrp web tests
-- Printing message in UserController when team member mapping fails instead of stacktrace as it is ignorable
 
 Fixes
 =====
-- Fixed the issue where code was assigning wrong ID to subform entities
-- 
+- Fixed #65. HH now submits with empty repeat group. 
+Note: This is not a solution but a hack because actual change should be in client/mobile app. 
+The code only guess empty group by empty first name not identifier assigned
 
 Known Issues
 ============


### PR DESCRIPTION
Fixed #65 
Note: This is not a solution but a hack because actual change should be in client/mobile app. 
The code only guess empty group by empty first name not identifier assigned

New Features
============
Changes
=======
Fixes
=====
- Fixed #65. HH now submits with empty repeat group. 
Note: This is not a solution but a hack because actual change should be in client/mobile app. 
The code only guess empty group by empty first name not identifier assigned

Known Issues
============
