### PR TITLE
Openmrs connector allows pushing scheduling data

### DIFF
--- a/assets/config/opensrp.properties
+++ b/assets/config/opensrp.properties
@@ -25,9 +25,12 @@ couchdb.server=localhost
 couchdb.port=5984
 
 # OpenMRS configuration
-openmrs.url=http://46.101.51.199:8080/openmrs/
+openmrs.url=http://localhost:8181/openmrs/
 openmrs.username=admin
-openmrs.password=5rpAdmin
+openmrs.password=Admin321
+
+# make REST calls and push data while testing on the server specified above
+openmrs.test.make-rest-call=false
 
 openmrs.scheduletracker.syncer.interval-min=2
 

--- a/assets/config/opensrp.properties
+++ b/assets/config/opensrp.properties
@@ -29,6 +29,8 @@ openmrs.url=http://46.101.51.199:8080/openmrs/
 openmrs.username=admin
 openmrs.password=5rpAdmin
 
+openmrs.scheduletracker.syncer.interval-min=2
+
 # properties for postgres db in opensrp-web and opensrp-reporting modules
 jdbc.backend=postgres
 jdbc.driverClassName=org.postgresql.Driver

--- a/build/maven.properties
+++ b/build/maven.properties
@@ -1,9 +1,9 @@
 #database configuration that is not likely to change unless massive refactoring  
-couchdb.db.opensrp=drishti
-couchdb.db.form=drishti-form
-couchdb.db.mcts=drishti-mcts
+couchdb.db.opensrp=opensrp
+couchdb.db.form=opensrp-form
+couchdb.db.mcts=opensrp-mcts
 couchdb.db.motech-scheduletracking=motech-scheduletracking-api
-couchdb.db.error=drishti-errortrace
+couchdb.db.error=opensrp-errortrace
 
 
 db.quartz=motechquartz

--- a/opensrp-api/src/main/java/org/opensrp/api/domain/BaseEntity.java
+++ b/opensrp-api/src/main/java/org/opensrp/api/domain/BaseEntity.java
@@ -174,10 +174,16 @@ public class BaseEntity extends BaseDataObject{
 	}
 
 	public Map<String, Object> getAttributes() {
+		if(attributes == null){
+			attributes = new HashMap<String, Object>();
+		}
 		return attributes;
 	}
 	
 	public Object getAttribute(String name) {
+		if(attributes == null){
+			attributes = new HashMap<String, Object>();
+		}
 		for (Entry<String, Object> a : attributes.entrySet()) {
 			if(a.getKey().equalsIgnoreCase(name)){
 				return a.getValue();
@@ -204,6 +210,9 @@ public class BaseEntity extends BaseDataObject{
 	}
 
 	public void removeAttribute(String name) {
+		if(attributes == null){
+			attributes = new HashMap<String, Object>();
+		}
 		for (Entry<String, Object> a : attributes.entrySet()) {
 			if(a.getKey().equalsIgnoreCase(name)){
 				attributes.remove(a.getKey());

--- a/opensrp-api/src/test/java/org/opensrp/api/AddressTest.java
+++ b/opensrp-api/src/test/java/org/opensrp/api/AddressTest.java
@@ -27,24 +27,6 @@ public class AddressTest {
 		assertTrue("Duration of Address should be -1 for no startDate", address.durationInWeeks()==-1);
 		assertTrue("Duration of Address should be -1 for no startDate", address.durationInMonths()==-1);
 		assertTrue("Duration of Address should be -1 for no startDate", address.durationInYears()==-1);
-		
-		long currentTicks = System.currentTimeMillis();
-		long weekTicks = 604800000L;
-		long yearTicks = 31536000000L;
-		Date d1 = new Date(currentTicks - weekTicks);
-		Date d2 = new Date(currentTicks - yearTicks);
-		
-		address.setStartDate(d1);
-		//TODO duration in days occasionally returning wrong value. check it
-		//assertTrue("Address durationInDays returns unexpected value", address.durationInDays()==7);
-		assertTrue("Address durationInWeeks returns unexpected value", address.durationInWeeks()==1);
-		assertTrue("Address durationInMonths returns unexpected value", address.durationInMonths()==0);
-		assertTrue("Address durationInYears returns unexpected value", address.durationInYears()==0);		
-
-		address.setStartDate(d2);
-		assertTrue("Address durationInWeeks returns unexpected value "+address.durationInWeeks(), address.durationInWeeks()==52);
-		assertTrue("Address durationInMonths returns unexpected value "+address.durationInMonths(), address.durationInMonths()==12);
-		assertTrue("Address durationInYears returns unexpected value "+address.durationInYears(), address.durationInYears()==1);
 	}
 	
 	@Test

--- a/opensrp-connector/src/main/java/org/opensrp/connector/OpenmrsConnector.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/OpenmrsConnector.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.opensrp.api.domain.Address;
 import org.opensrp.api.domain.BaseEntity;
 import org.opensrp.api.domain.Client;
@@ -296,8 +297,28 @@ public class OpenmrsConnector {
 		Date birthdate = OpenmrsService.OPENMRS_DATE.parse(fs.getField(getFieldName(Person.birthdate, fs)));
 		String dd = fs.getField(getFieldName(Person.deathdate, fs));
 		Date deathdate = dd==null?null:OpenmrsService.OPENMRS_DATE.parse(dd);
+		String aproxbd = fs.getField(getFieldName(Person.birthdate_estimated, fs));
 		Boolean birthdateApprox = false;
+		if(!StringUtils.isEmptyOrWhitespaceOnly(aproxbd) && NumberUtils.isNumber(aproxbd)){
+			int bde = 0;
+			try {
+				bde = Integer.parseInt(aproxbd);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			birthdateApprox = bde > 0 ? true:false;
+		}
+		String aproxdd = fs.getField(getFieldName(Person.deathdate_estimated, fs));
 		Boolean deathdateApprox = false;
+		if(!StringUtils.isEmptyOrWhitespaceOnly(aproxdd) && NumberUtils.isNumber(aproxdd)){
+			int dde = 0;
+			try {
+				dde = Integer.parseInt(aproxdd);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			deathdateApprox = dde > 0 ? true:false;
+		}
 		String gender = fs.getField(getFieldName(Person.gender, fs));
 		
 		List<Address> addresses = new ArrayList<>(extractAddresses(fs, null).values());
@@ -342,8 +363,28 @@ public class OpenmrsConnector {
 					Date birthdate = OpenmrsService.OPENMRS_DATE.parse(sfdata.get(getFieldName(Person.birthdate, sbf.name(), fs)));
 					String dd = sfdata.get(getFieldName(Person.deathdate, sbf.name(), fs));
 					Date deathdate = dd==null?null:OpenmrsService.OPENMRS_DATE.parse(dd);
-					Boolean birthdateApprox = true;
-					Boolean deathdateApprox = true;
+					String aproxbd = sfdata.get(getFieldName(Person.birthdate_estimated, sbf.name(), fs));
+					Boolean birthdateApprox = false;
+					if(!StringUtils.isEmptyOrWhitespaceOnly(aproxbd) && NumberUtils.isNumber(aproxbd)){
+						int bde = 0;
+						try {
+							bde = Integer.parseInt(aproxbd);
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+						birthdateApprox = bde > 0 ? true:false;
+					}
+					String aproxdd = sfdata.get(getFieldName(Person.deathdate_estimated, sbf.name(), fs));
+					Boolean deathdateApprox = false;
+					if(!StringUtils.isEmptyOrWhitespaceOnly(aproxdd) && NumberUtils.isNumber(aproxdd)){
+						int dde = 0;
+						try {
+							dde = Integer.parseInt(aproxdd);
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+						deathdateApprox = dde > 0 ? true:false;
+					}
 					String gender = sfdata.get(getFieldName(Person.gender, sbf.name(), fs));
 					
 					List<Address> addresses = new ArrayList<>(extractAddresses(fs, sbf.name()).values());

--- a/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/constants/OpenmrsConstants.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/constants/OpenmrsConstants.java
@@ -7,8 +7,11 @@ package org.opensrp.connector.openmrs.constants;
 public class OpenmrsConstants {
 
 	public static final String SCHEDULER_TRACKER_SYNCER_SUBJECT = "OpenMRS Scheduler Tracker Syncer";
+	public static final String ENROLLMENT_TRACK_UUID = "openmrsTrackUuid";
+
+
 	public enum ScheduleTrackerConfig {
-		openmrs_syncer_last_timestamp_non_active_enrollment,
+		openmrs_syncer_sync_by_last_update_enrollment,
 		openmrs_syncer_sync_status,
 		openmrs_syncer_sync_timestamp
 	}

--- a/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/constants/OpenmrsConstants.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/constants/OpenmrsConstants.java
@@ -6,6 +6,13 @@ package org.opensrp.connector.openmrs.constants;
  */
 public class OpenmrsConstants {
 
+	public static final String SCHEDULER_TRACKER_SYNCER_SUBJECT = "OpenMRS Scheduler Tracker Syncer";
+	public enum ScheduleTrackerConfig {
+		openmrs_syncer_last_timestamp_non_active_enrollment,
+		openmrs_syncer_sync_status,
+		openmrs_syncer_sync_timestamp
+	}
+	
 	public interface OpenmrsEntity {
 		public String entity();
 		public String entityId();

--- a/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerService.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerService.java
@@ -11,7 +11,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.motechproject.scheduletracking.api.domain.Enrollment;
 import org.motechproject.scheduletracking.api.domain.MilestoneFulfillment;
+import org.opensrp.common.util.HttpResponse;
 import org.opensrp.connector.HttpUtil;
+import org.opensrp.connector.openmrs.constants.OpenmrsConstants;
 import org.opensrp.scheduler.Action;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -95,6 +97,51 @@ public class OpenmrsSchedulerService extends OpenmrsService{
 				tm.put("actionType", "PROVIDER ALERT");
 				
 				JSONObject tmo = new JSONObject(HttpUtil.post(getURL()+"/"+TRACK_MILESTONE_URL, "", tm.toString(), OPENMRS_USER, OPENMRS_PWD).body());
+			
+				tmarr.put(tmo);
+			}
+		}
+		
+		to.put("trackMilestones", tmarr);
+		return to;
+	}
+	
+	public JSONObject updateTrack(Enrollment e, List<Action> alertActions) throws JSONException, ParseException
+	{
+		JSONObject t = new JSONObject();
+		t.put("beneficiaryRole", alertActions!=null&&alertActions.size()>0?alertActions.get(0).data().get("beneficiaryType"):null);
+		String hr = StringUtils.leftPad(e.getPreferredAlertTime().getHour().toString(),2,"0");
+		String mn = StringUtils.leftPad(e.getPreferredAlertTime().getMinute().toString(),2,"0");
+		t.put("preferredAlertTime", hr+":"+mn+":00");
+		t.put("currentMilestone", e.getCurrentMilestoneName());
+		t.put("status", e.getStatus().name());
+		
+		
+		JSONObject to = new JSONObject(HttpUtil.post(getURL()+"/"+TRACK_URL+"/"+e.getMetadata().get(OpenmrsConstants.ENROLLMENT_TRACK_UUID), "", t.toString(), OPENMRS_USER, OPENMRS_PWD).body());
+		String trackuuid = to.getString("uuid");
+		
+		JSONArray tmarr = new JSONArray();
+		for (Action ac : alertActions) {
+			if(ac.actionType().equalsIgnoreCase("createAlert")){
+				String milestone = ac.data().get("visitCode");
+				JSONArray j = new JSONObject(HttpUtil.get(getURL()+"/"+TRACK_MILESTONE_URL, "v=full&track="+trackuuid+"&milestone="+milestone, OPENMRS_USER, OPENMRS_PWD).body()).getJSONArray("results");
+				JSONObject tm = new JSONObject();
+				String uuid = j.length()>0?j.getJSONObject(0).getString("uuid"):"";
+				Action close = getClosedAction(milestone, alertActions);
+				MilestoneFulfillment m = getMilestone(milestone, e);
+				String fdate = m == null?null:OPENMRS_DATE.format(m.getFulfillmentDateTime().toDate());
+				if(fdate == null){
+					fdate = close==null?null:OPENMRS_DATE.format(new SimpleDateFormat("dd-MM-yyyy").parse(close.data().get("completionDate")));
+				}
+				tm.put("fulfillmentDate", fdate);
+				tm.put("status", ac.data().get("alertStatus")+(close==null?"":"-completed"));
+				//TODO tm.put("reasonClosed", ac.data().get(""));
+				tm.put("alertStartDate", ac.data().get("startDate"));
+				tm.put("alertExpiryDate", ac.data().get("expiryDate"));
+				tm.put("isActive", ac.getIsActionActive());
+				tm.put("actionType", "PROVIDER ALERT");
+				
+				JSONObject tmo = new JSONObject(HttpUtil.post(getURL()+"/"+TRACK_MILESTONE_URL+"/"+uuid, "", tm.toString(), OPENMRS_USER, OPENMRS_PWD).body());
 			
 				tmarr.put(tmo);
 			}

--- a/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerService.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerService.java
@@ -1,0 +1,124 @@
+
+package org.opensrp.connector.openmrs.service;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.motechproject.scheduletracking.api.domain.Enrollment;
+import org.motechproject.scheduletracking.api.domain.MilestoneFulfillment;
+import org.opensrp.connector.HttpUtil;
+import org.opensrp.scheduler.Action;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OpenmrsSchedulerService extends OpenmrsService{
+	
+	private static final String TRACK_URL = "ws/rest/v1/scheduletracker/track";
+	private static final String TRACK_MILESTONE_URL = "ws/rest/v1/scheduletracker/trackmilestone";
+	private static final String SCHEDULE_URL = "ws/rest/v1/scheduletracker/schedule";
+	private static final String MILESTONE_URL = "ws/rest/v1/scheduletracker/milestone";
+	
+	private OpenmrsUserService userService;
+
+	public OpenmrsUserService getUserService() {
+		return userService;
+	}
+
+	public void setUserService(OpenmrsUserService userService) {
+		this.userService = userService;
+	}
+
+	@Autowired
+	public OpenmrsSchedulerService(OpenmrsUserService userService) {
+		this.userService = userService;
+	}
+
+    public OpenmrsSchedulerService(String openmrsUrl, String user, String password) {
+    	super(openmrsUrl, user, password);
+    }
+	
+	public JSONObject createTrack(Enrollment e, List<Action> alertActions) throws JSONException, ParseException
+	{
+		JSONObject t = new JSONObject();
+		t.put("beneficiary", e.getExternalId());
+		t.put("beneficiaryRole", alertActions!=null&&alertActions.size()>0?alertActions.get(0).data().get("beneficiaryType"):null);
+		t.put("schedule", e.getScheduleName());
+		String hr = StringUtils.leftPad(e.getPreferredAlertTime().getHour().toString(),2,"0");
+		String mn = StringUtils.leftPad(e.getPreferredAlertTime().getMinute().toString(),2,"0");
+		t.put("preferredAlertTime", hr+":"+mn+":00");
+		t.put("referenceDate", OPENMRS_DATE.format(e.getStartOfSchedule().toDate()));
+		t.put("referenceDateType", "MANUAL");
+		t.put("dateEnrolled", OPENMRS_DATE.format(e.getEnrolledOn().toDate()));
+		
+		/*DateTime earliestStart = e.getStartOfWindowForCurrentMilestone(WindowName.earliest);
+        DateTime dueStart = e.getStartOfWindowForCurrentMilestone(WindowName.due);
+        DateTime lateStart = e.getStartOfWindowForCurrentMilestone(WindowName.late);
+        DateTime maxStart = e.getStartOfWindowForCurrentMilestone(WindowName.max);
+		t.put("earlyStartDate", OPENMRS_DATE.format(earliestStart.toDate()));
+		t.put("dueStartDate", OPENMRS_DATE.format(dueStart.toDate()));
+		t.put("lateStartDate", OPENMRS_DATE.format(lateStart.toDate()));
+		t.put("maxStartDate", OPENMRS_DATE.format(maxStart.toDate()));*/
+		t.put("currentMilestone", e.getCurrentMilestoneName());
+		t.put("status", e.getStatus().name());
+		
+		
+		JSONObject to = new JSONObject(HttpUtil.post(getURL()+"/"+TRACK_URL, "", t.toString(), OPENMRS_USER, OPENMRS_PWD).body());
+		String trackuuid = to.getString("uuid");
+		
+		JSONArray tmarr = new JSONArray();
+		for (Action ac : alertActions) {
+			if(ac.actionType().equalsIgnoreCase("createAlert")){
+				Action close = getClosedAction(ac.data().get("visitCode"), alertActions);
+				JSONObject pr = userService.getPersonByUser(ac.anmIdentifier());
+				JSONObject tm = new JSONObject();
+				tm.put("track", trackuuid);
+				MilestoneFulfillment m = getMilestone(ac.data().get("visitCode"), e);
+				tm.put("milestone", ac.data().get("visitCode"));
+				tm.put("alertRecipient", pr.getString("uuid"));
+				tm.put("alertRecipientRole", "PROVIDER");
+				String fdate = m == null?null:OPENMRS_DATE.format(m.getFulfillmentDateTime().toDate());
+				if(fdate == null){
+					fdate = close==null?null:OPENMRS_DATE.format(new SimpleDateFormat("dd-MM-yyyy").parse(close.data().get("completionDate")));
+				}
+				tm.put("fulfillmentDate", fdate);
+				tm.put("status", ac.data().get("alertStatus")+(close==null?"":"-completed"));
+				//TODO tm.put("reasonClosed", ac.data().get(""));
+				tm.put("alertStartDate", ac.data().get("startDate"));
+				tm.put("alertExpiryDate", ac.data().get("expiryDate"));
+				tm.put("isActive", ac.getIsActionActive());
+				tm.put("actionType", "PROVIDER ALERT");
+				
+				JSONObject tmo = new JSONObject(HttpUtil.post(getURL()+"/"+TRACK_MILESTONE_URL, "", tm.toString(), OPENMRS_USER, OPENMRS_PWD).body());
+			
+				tmarr.put(tmo);
+			}
+		}
+		
+		t.put("trackMilestones", tmarr);
+		return t;
+	}
+	
+	private Action getClosedAction(String milestone, List<Action> actions){
+		for (Action a : actions) {
+			if(a.data().get("visitCode") != null && a.data().get("visitCode").equalsIgnoreCase(milestone)
+					&& a.actionType().equalsIgnoreCase("closeAlert")){
+				return a;
+			}
+		}
+		return null;
+	}
+	private MilestoneFulfillment getMilestone(String milestone, Enrollment e) {
+		for (MilestoneFulfillment m : e.getFulfillments()) {
+			if(m.getMilestoneName().equalsIgnoreCase(milestone)){
+				return m;
+			}
+		}
+		return null;
+	}
+}

--- a/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/OpenmrsUserService.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/OpenmrsUserService.java
@@ -13,6 +13,7 @@ public class OpenmrsUserService extends OpenmrsService{
 
 	private static final String AUTHENTICATION_URL = "ws/rest/v1/session";
 	private static final String USER_URL = "ws/rest/v1/user";
+	private static final String PROVIDER_URL = "ws/rest/v1/provider";
 	private static final String TEAM_MEMBER_URL = "ws/rest/v1/teammodule/member";
 	
     public OpenmrsUserService() { }
@@ -74,5 +75,23 @@ public class OpenmrsUserService extends OpenmrsService{
 	public JSONObject getTeamMember(String uuid) throws JSONException{
 		HttpResponse op = HttpUtil.get(HttpUtil.removeEndingSlash(OPENMRS_BASE_URL)+"/"+TEAM_MEMBER_URL+"/"+uuid, "v=full", OPENMRS_USER, OPENMRS_PWD);
 		return new JSONObject(op.body());
+	}
+	
+	public JSONObject getProvider(String identifier) throws JSONException{
+		HttpResponse op = HttpUtil.get(HttpUtil.removeEndingSlash(OPENMRS_BASE_URL)+"/"+PROVIDER_URL, "v=full&q="+identifier, OPENMRS_USER, OPENMRS_PWD);
+		JSONArray res = new JSONObject(op.body()).getJSONArray("results");
+		if(res.length() == 0){
+			return null;
+		}
+		JSONObject obj = res.getJSONObject(0);
+		return obj;
+	}
+	
+	public JSONObject createProvider(String existingUsername, String identifier) throws JSONException
+	{
+		JSONObject p = new JSONObject();
+		p.put("person", getPersonByUser(existingUsername).getString("uuid"));
+		p.put("identifier", identifier);
+		return new JSONObject(HttpUtil.post(getURL()+"/"+PROVIDER_URL, "", p.toString(), OPENMRS_USER, OPENMRS_PWD).body());
 	}
 }

--- a/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/PatientService.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/PatientService.java
@@ -173,6 +173,7 @@ public class PatientService extends OpenmrsService{
 		JSONObject p = new JSONObject();
 		p.put("person", createPerson(c.getBaseEntity()).getString("uuid"));
 		JSONArray ids = new JSONArray();
+		if(c.getIdentifiers() != null){
 		for (Entry<String, String> id : c.getIdentifiers().entrySet()) {
 			JSONObject jio = new JSONObject();
 			JSONObject idobj = getIdentifierType(id.getKey());
@@ -186,7 +187,7 @@ public class PatientService extends OpenmrsService{
 			//jio.put("preferred", true);
 
 			ids.put(jio);
-		}
+		}}
 		
 		JSONObject jio = new JSONObject();
 		JSONObject ido = getIdentifierType(OPENSRP_IDENTIFIER_TYPE);

--- a/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/PatientService.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/openmrs/service/PatientService.java
@@ -12,7 +12,6 @@ import org.opensrp.api.domain.Address;
 import org.opensrp.api.domain.BaseEntity;
 import org.opensrp.api.domain.Client;
 import org.opensrp.connector.HttpUtil;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 

--- a/opensrp-connector/src/main/java/org/opensrp/connector/schedule/OpenmrsSyncerListener.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/schedule/OpenmrsSyncerListener.java
@@ -1,0 +1,64 @@
+package org.opensrp.connector.schedule;
+
+import java.text.ParseException;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.json.JSONException;
+import org.motechproject.scheduler.domain.MotechEvent;
+import org.motechproject.scheduletracking.api.domain.Enrollment;
+import org.motechproject.scheduletracking.api.domain.EnrollmentStatus;
+import org.motechproject.scheduletracking.api.domain.WindowName;
+import org.motechproject.server.event.annotations.MotechListener;
+import org.opensrp.connector.openmrs.constants.OpenmrsConstants;
+import org.opensrp.connector.openmrs.constants.OpenmrsConstants.ScheduleTrackerConfig;
+import org.opensrp.connector.openmrs.service.OpenmrsSchedulerService;
+import org.opensrp.domain.AppStateToken;
+import org.opensrp.scheduler.HealthSchedulerService;
+import org.opensrp.scheduler.repository.AllActions;
+import org.opensrp.scheduler.service.ActionService;
+import org.opensrp.scheduler.service.ScheduleService;
+import org.opensrp.service.ConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenmrsSyncerListener {
+
+	private OpenmrsSchedulerService openmrsSchedulerService;
+	private ScheduleService opensrpScheduleService;
+	private ActionService actionService;
+	private ConfigService config;
+	
+	@Autowired
+	public OpenmrsSyncerListener(OpenmrsSchedulerService openmrsSchedulerService, 
+			ScheduleService opensrpScheduleService, ActionService actionService, ConfigService config) {
+		this.openmrsSchedulerService = openmrsSchedulerService;
+		this.opensrpScheduleService = opensrpScheduleService;
+		this.actionService = actionService;
+		this.config = config;
+	}
+	
+    @MotechListener(subjects = OpenmrsConstants.SCHEDULER_TRACKER_SYNCER_SUBJECT)
+	public void scheduletrackerSyncer(MotechEvent event) {
+    	AppStateToken lastsync = config.getAppStateTokenByName(ScheduleTrackerConfig.openmrs_syncer_last_timestamp_non_active_enrollment);
+    	DateTime start = lastsync == null?new DateTime().minusYears(33):new DateTime(lastsync.getStringValue());
+		DateTime end = new DateTime().plusYears(2);
+		List<Enrollment> el = opensrpScheduleService.findEnrollmentByStatusAndEnrollmentDate(EnrollmentStatus.COMPLETED.name(), start, end);
+    	for (Enrollment e : el){
+			DateTime alertstart = e.getStartOfSchedule();
+			DateTime alertend = e.getLastFulfilledDate();
+			if(alertend == null){
+				alertend = e.getCurrentMilestoneStartDate();
+			}
+    		try {
+				openmrsSchedulerService.createTrack(e, actionService.findByCaseIdScheduleAndTimeStamp(e.getExternalId(), e.getScheduleName(), alertstart, alertend));
+			} catch (JSONException e1) {
+				e1.printStackTrace();
+			} catch (ParseException e1) {
+				// TODO Auto-generated catch block
+				e1.printStackTrace();
+			}
+    	}
+	}
+}

--- a/opensrp-connector/src/main/java/org/opensrp/connector/schedule/OpenmrsSyncerListener.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/schedule/OpenmrsSyncerListener.java
@@ -1,13 +1,11 @@
 package org.opensrp.connector.schedule;
 
-import java.text.ParseException;
 import java.util.List;
 
 import org.joda.time.DateTime;
-import org.json.JSONException;
+import org.json.JSONObject;
 import org.motechproject.scheduler.domain.MotechEvent;
 import org.motechproject.scheduletracking.api.domain.Enrollment;
-import org.motechproject.scheduletracking.api.domain.EnrollmentStatus;
 import org.motechproject.server.event.annotations.MotechListener;
 import org.opensrp.connector.openmrs.constants.OpenmrsConstants;
 import org.opensrp.connector.openmrs.constants.OpenmrsConstants.ScheduleTrackerConfig;
@@ -16,6 +14,7 @@ import org.opensrp.domain.AppStateToken;
 import org.opensrp.scheduler.service.ActionService;
 import org.opensrp.scheduler.service.ScheduleService;
 import org.opensrp.service.ConfigService;
+import org.opensrp.service.ErrorTraceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -26,38 +25,46 @@ public class OpenmrsSyncerListener {
 	private ScheduleService opensrpScheduleService;
 	private ActionService actionService;
 	private ConfigService config;
+	private ErrorTraceService errorTraceService;
 	
 	@Autowired
 	public OpenmrsSyncerListener(OpenmrsSchedulerService openmrsSchedulerService, 
-			ScheduleService opensrpScheduleService, ActionService actionService, ConfigService config) {
+			ScheduleService opensrpScheduleService, ActionService actionService, 
+			ConfigService config, ErrorTraceService errorTraceService) {
 		this.openmrsSchedulerService = openmrsSchedulerService;
 		this.opensrpScheduleService = opensrpScheduleService;
 		this.actionService = actionService;
 		this.config = config;
+		this.errorTraceService = errorTraceService;
 	}
 	
     @MotechListener(subjects = OpenmrsConstants.SCHEDULER_TRACKER_SYNCER_SUBJECT)
 	public void scheduletrackerSyncer(MotechEvent event) {
     	try{
-    	AppStateToken lastsync = config.getAppStateTokenByName(ScheduleTrackerConfig.openmrs_syncer_last_timestamp_non_active_enrollment);
-    	DateTime start = lastsync == null?new DateTime().minusYears(33):new DateTime(lastsync.getStringValue());
-		DateTime end = new DateTime().plusYears(2);
-		List<Enrollment> el = opensrpScheduleService.findEnrollmentByStatusAndEnrollmentDate(EnrollmentStatus.COMPLETED.name(), start, end);
-    	for (Enrollment e : el){
-			DateTime alertstart = e.getStartOfSchedule();
-			DateTime alertend = e.getLastFulfilledDate();
-			if(alertend == null){
-				alertend = e.getCurrentMilestoneStartDate();
-			}
-    		try {
-				openmrsSchedulerService.createTrack(e, actionService.findByCaseIdScheduleAndTimeStamp(e.getExternalId(), e.getScheduleName(), alertstart, alertend));
-			} catch (JSONException e1) {
-				e1.printStackTrace();
-			} catch (ParseException e1) {
-				// TODO Auto-generated catch block
-				e1.printStackTrace();
-			}
-    	}
+	    	AppStateToken lastsync = config.getAppStateTokenByName(ScheduleTrackerConfig.openmrs_syncer_sync_by_last_update_enrollment);
+	    	DateTime start = lastsync == null?new DateTime().minusYears(33):new DateTime(lastsync.getStringValue());
+			DateTime end = new DateTime();
+			List<Enrollment> el = opensrpScheduleService.findEnrollmentByLastUpDate(start, end);
+	    	for (Enrollment e : el){
+				DateTime alertstart = e.getStartOfSchedule();
+				DateTime alertend = e.getLastFulfilledDate();
+				if(alertend == null){
+					alertend = e.getCurrentMilestoneStartDate();
+				}
+	    		try {
+	    			if(e.getMetadata().get(OpenmrsConstants.ENROLLMENT_TRACK_UUID) != null){
+	    				
+	    			}
+	    			else{
+	    				JSONObject tr = openmrsSchedulerService.createTrack(e, actionService.findByCaseIdScheduleAndTimeStamp(e.getExternalId(), e.getScheduleName(), alertstart, alertend));
+	    				opensrpScheduleService.updateEnrollmentWithMetadata(e.getId(), OpenmrsConstants.ENROLLMENT_TRACK_UUID, tr.getString("uuid"));
+	    			}
+				} catch (Exception e1) {
+					e1.printStackTrace();
+					errorTraceService.log("ScheduleTracker Syncer Inactive Schedule", Enrollment.class.getName(), e.getId(), e1.getStackTrace().toString(), "");
+				}
+	    	}
+	    	config.updateAppStateToken(ScheduleTrackerConfig.openmrs_syncer_sync_by_last_update_enrollment, end);
     	}
     	catch(Exception e){
     		e.printStackTrace();

--- a/opensrp-connector/src/main/java/org/opensrp/connector/schedule/OpenmrsSyncerListener.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/schedule/OpenmrsSyncerListener.java
@@ -8,14 +8,11 @@ import org.json.JSONException;
 import org.motechproject.scheduler.domain.MotechEvent;
 import org.motechproject.scheduletracking.api.domain.Enrollment;
 import org.motechproject.scheduletracking.api.domain.EnrollmentStatus;
-import org.motechproject.scheduletracking.api.domain.WindowName;
 import org.motechproject.server.event.annotations.MotechListener;
 import org.opensrp.connector.openmrs.constants.OpenmrsConstants;
 import org.opensrp.connector.openmrs.constants.OpenmrsConstants.ScheduleTrackerConfig;
 import org.opensrp.connector.openmrs.service.OpenmrsSchedulerService;
 import org.opensrp.domain.AppStateToken;
-import org.opensrp.scheduler.HealthSchedulerService;
-import org.opensrp.scheduler.repository.AllActions;
 import org.opensrp.scheduler.service.ActionService;
 import org.opensrp.scheduler.service.ScheduleService;
 import org.opensrp.service.ConfigService;
@@ -41,6 +38,7 @@ public class OpenmrsSyncerListener {
 	
     @MotechListener(subjects = OpenmrsConstants.SCHEDULER_TRACKER_SYNCER_SUBJECT)
 	public void scheduletrackerSyncer(MotechEvent event) {
+    	try{
     	AppStateToken lastsync = config.getAppStateTokenByName(ScheduleTrackerConfig.openmrs_syncer_last_timestamp_non_active_enrollment);
     	DateTime start = lastsync == null?new DateTime().minusYears(33):new DateTime(lastsync.getStringValue());
 		DateTime end = new DateTime().plusYears(2);
@@ -59,6 +57,10 @@ public class OpenmrsSyncerListener {
 				// TODO Auto-generated catch block
 				e1.printStackTrace();
 			}
+    	}
+    	}
+    	catch(Exception e){
+    		e.printStackTrace();
     	}
 	}
 }

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/EncounterTest.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/EncounterTest.java
@@ -2,6 +2,7 @@
 package org.opensrp.connector.openmrs.service;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -132,5 +133,41 @@ public class EncounterTest extends TestResourceLoader{
 				
 		Map<String, Map<String, Object>> dc = oc.getDependentClientsFromFormSubmission(fs);
 		assertTrue(dc.isEmpty());
+	}	
+	
+	@Test
+	public void shouldGetBirthdateNotEstimatedForMainAndApproxForRepeatGroup() throws IOException, ParseException, JSONException{
+		FormSubmission fs = getFormSubmissionFor("new_household_registration", 7);
+
+		assertTrue(oc.isOpenmrsForm(fs));
+		
+		Client c = oc.getClientFromFormSubmission(fs);
+		assertEquals(c.getBaseEntity().getBirthdate(), sd.parse("1900-01-01"));
+		assertTrue(c.getBaseEntity().getBirthdateApprox());
+		
+		Map<String, Map<String, Object>> dc = oc.getDependentClientsFromFormSubmission(fs);
+		for (String id : dc.keySet()) {
+			Client cl = (Client) dc.get(id).get("client");
+			assertEquals(cl.getBaseEntity().getBirthdate(), sd.parse("2000-05-07"));
+			assertFalse(cl.getBaseEntity().getBirthdateApprox());
+		}
+	}	
+	
+	@Test
+	public void shouldGetBirthdateNotEstimatedForMainAndRepeatGroupIfNotSpecified() throws IOException, ParseException, JSONException{
+		FormSubmission fs = getFormSubmissionFor("new_household_registration", 8);
+
+		assertTrue(oc.isOpenmrsForm(fs));
+		
+		Client c = oc.getClientFromFormSubmission(fs);
+		assertEquals(c.getBaseEntity().getBirthdate(), sd.parse("1900-01-01"));
+		assertFalse(c.getBaseEntity().getBirthdateApprox());
+		
+		Map<String, Map<String, Object>> dc = oc.getDependentClientsFromFormSubmission(fs);
+		for (String id : dc.keySet()) {
+			Client cl = (Client) dc.get(id).get("client");
+			assertEquals(cl.getBaseEntity().getBirthdate(), sd.parse("2000-05-07"));
+			assertFalse(cl.getBaseEntity().getBirthdateApprox());
+		}
 	}	
 }

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/HouseHoldTest.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/HouseHoldTest.java
@@ -106,7 +106,7 @@ public class HouseHoldTest extends TestResourceLoader{
 				
 				Event depe = (Event)cm.get("event");
 				assertFalse(depe.getObs().isEmpty());
-				assertEquals(2, depe.getObs().size());
+				assertEquals(1, depe.getObs().size());
 			}
 		}
 	}

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
@@ -1,0 +1,60 @@
+package org.opensrp.connector.openmrs.service;
+
+import static org.opensrp.dto.AlertStatus.normal;
+import static org.opensrp.dto.BeneficiaryType.mother;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.motechproject.model.Time;
+import org.motechproject.scheduletracking.api.domain.Enrollment;
+import org.motechproject.scheduletracking.api.domain.EnrollmentStatus;
+import org.motechproject.scheduletracking.api.domain.Schedule;
+import org.opensrp.dto.ActionData;
+import org.opensrp.scheduler.Action;
+
+public class OpenmrsSchedulerServiceTest extends TestResourceLoader{
+	public OpenmrsSchedulerServiceTest() throws IOException {
+		super();
+	}
+
+	OpenmrsSchedulerService ss;
+	OpenmrsUserService us;
+
+	SimpleDateFormat sd = new SimpleDateFormat("yyyy-MM-dd");
+	
+	@Before
+	public void setup() throws IOException{
+		openmrsOpenmrsUrl = "http://localhost:8181/openmrs";
+		openmrsUsername = "admin";
+		openmrsPassword = "Admin321";
+		ss = new OpenmrsSchedulerService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
+		us = new OpenmrsUserService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
+		ss.setUserService(us);;
+	}
+	
+	@Test
+	public void testTrack() throws JSONException, ParseException {
+		Enrollment e = new Enrollment("abc2831e-1e0d-4707-877b-22961e01e753", new Schedule("Boosters"), "REMINDER", 
+				new DateTime(2012, 1, 1, 0, 0), new DateTime(2012, 1, 1, 0, 0), new Time(23,8), EnrollmentStatus.ACTIVE, null);
+		List<Action> alertActions = new ArrayList<Action>();
+		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", alert("Boosters", "REMINDER")));
+		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", ActionData.markAlertAsClosed("REMINDER", "12-12-2015")));
+		ss.createTrack(e, alertActions);
+	}
+	
+	private ActionData alert() {
+        return ActionData.createAlert(mother, "Ante Natal Care - Normal", "ANC 1", normal, DateTime.now(), DateTime.now().plusDays(3));
+    }
+
+    private ActionData alert(String schedule, String milestone) {
+        return ActionData.createAlert(mother, schedule, milestone, normal, DateTime.now(), DateTime.now().plusDays(3));
+    }
+}

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
@@ -7,16 +7,20 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.joda.time.DateTime;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.motechproject.model.Time;
 import org.motechproject.scheduletracking.api.domain.Enrollment;
 import org.motechproject.scheduletracking.api.domain.EnrollmentStatus;
 import org.motechproject.scheduletracking.api.domain.Schedule;
+import org.opensrp.connector.openmrs.constants.OpenmrsConstants;
 import org.opensrp.dto.ActionData;
 import org.opensrp.scheduler.Action;
 
@@ -47,7 +51,12 @@ public class OpenmrsSchedulerServiceTest extends TestResourceLoader{
 		List<Action> alertActions = new ArrayList<Action>();
 		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", alert("Boosters", "REMINDER")));
 		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", ActionData.markAlertAsClosed("REMINDER", "12-12-2015")));
-		//ss.createTrack(e, alertActions);
+		//JSONObject t = ss.createTrack(e, alertActions);
+		e.setStatus(EnrollmentStatus.COMPLETED);
+		Map<String, String> metadata = new HashMap<>();
+		//metadata.put(OpenmrsConstants.ENROLLMENT_TRACK_UUID, t.getString("uuid"));
+		e.setMetadata(metadata );
+		//ss.updateTrack(e, alertActions);
 	}
 	
 	private ActionData alert() {

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
@@ -47,7 +47,7 @@ public class OpenmrsSchedulerServiceTest extends TestResourceLoader{
 		List<Action> alertActions = new ArrayList<Action>();
 		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", alert("Boosters", "REMINDER")));
 		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", ActionData.markAlertAsClosed("REMINDER", "12-12-2015")));
-		ss.createTrack(e, alertActions);
+		//ss.createTrack(e, alertActions);
 	}
 	
 	private ActionData alert() {

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/OpenmrsSchedulerServiceTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.joda.time.DateTime;
 import org.json.JSONException;
@@ -20,9 +21,17 @@ import org.motechproject.model.Time;
 import org.motechproject.scheduletracking.api.domain.Enrollment;
 import org.motechproject.scheduletracking.api.domain.EnrollmentStatus;
 import org.motechproject.scheduletracking.api.domain.Schedule;
+import org.opensrp.api.domain.Client;
+import org.opensrp.api.domain.Event;
+import org.opensrp.connector.FormAttributeMapper;
+import org.opensrp.connector.OpenmrsConnector;
 import org.opensrp.connector.openmrs.constants.OpenmrsConstants;
+import org.opensrp.connector.openmrs.constants.OpenmrsHouseHold;
 import org.opensrp.dto.ActionData;
+import org.opensrp.form.domain.FormSubmission;
 import org.opensrp.scheduler.Action;
+
+import com.google.gson.JsonIOException;
 
 public class OpenmrsSchedulerServiceTest extends TestResourceLoader{
 	public OpenmrsSchedulerServiceTest() throws IOException {
@@ -31,38 +40,147 @@ public class OpenmrsSchedulerServiceTest extends TestResourceLoader{
 
 	OpenmrsSchedulerService ss;
 	OpenmrsUserService us;
+	
+	EncounterService es;
+	OpenmrsConnector oc;
+	PatientService ps;
+	HouseholdService hhs;
 
 	SimpleDateFormat sd = new SimpleDateFormat("yyyy-MM-dd");
 	
 	@Before
 	public void setup() throws IOException{
-		openmrsOpenmrsUrl = "http://localhost:8181/openmrs";
-		openmrsUsername = "admin";
-		openmrsPassword = "Admin321";
-		ss = new OpenmrsSchedulerService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
+		ps = new PatientService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
 		us = new OpenmrsUserService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
-		ss.setUserService(us);;
+		ss = new OpenmrsSchedulerService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
+		ss.setUserService(us);
+		ss.setPatientService(ps);
+		
+		es = new EncounterService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
+		es.setPatientService(ps);
+		es.setUserService(us);
+		hhs = new HouseholdService(openmrsOpenmrsUrl, openmrsUsername, openmrsPassword);
+		hhs.setPatientService(ps);
+		hhs.setEncounterService(es);
+		FormAttributeMapper fam = new FormAttributeMapper(formDirPath);
+		oc = new OpenmrsConnector(fam);
 	}
 	
 	@Test
 	public void testTrack() throws JSONException, ParseException {
-		Enrollment e = new Enrollment("abc2831e-1e0d-4707-877b-22961e01e753", new Schedule("Boosters"), "REMINDER", 
+		String id = UUID.randomUUID().toString();
+		
+		Enrollment e = new Enrollment(id, new Schedule("Boosters"), "REMINDER", 
 				new DateTime(2012, 1, 1, 0, 0), new DateTime(2012, 1, 1, 0, 0), new Time(23,8), EnrollmentStatus.ACTIVE, null);
 		List<Action> alertActions = new ArrayList<Action>();
-		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", alert("Boosters", "REMINDER")));
-		alertActions.add(new Action("abc2831e-1e0d-4707-877b-22961e01e753", "admin", ActionData.markAlertAsClosed("REMINDER", "12-12-2015")));
-		//JSONObject t = ss.createTrack(e, alertActions);
-		e.setStatus(EnrollmentStatus.COMPLETED);
-		Map<String, String> metadata = new HashMap<>();
-		//metadata.put(OpenmrsConstants.ENROLLMENT_TRACK_UUID, t.getString("uuid"));
-		e.setMetadata(metadata );
-		//ss.updateTrack(e, alertActions);
+		alertActions.add(new Action(id, "admin", alert("Boosters", "REMINDER")));
+		alertActions.add(new Action(id, "admin", ActionData.markAlertAsClosed("REMINDER", "12-12-2015")));
+		if(pushToOpenmrsForTest){
+			JSONObject p = ps.getPatientByIdentifier(id);
+			if(p == null){
+				ps.createPatient(new Client(id, "TEST", null, "Name", new DateTime().minusYears(20).toDate(), null, false, false, "MALE"));
+			}
+			JSONObject t = ss.createTrack(e, alertActions);
+			e.setStatus(EnrollmentStatus.COMPLETED);
+			Map<String, String> metadata = new HashMap<>();
+			metadata.put(OpenmrsConstants.ENROLLMENT_TRACK_UUID, t.getString("uuid"));
+			e.setMetadata(metadata );
+			ss.updateTrack(e, alertActions);
+		}
+	}
+
+	@Test
+	public void testTrackWithoutAnyMilestoneOrAction() throws JSONException, ParseException {
+		String id = UUID.randomUUID().toString();
+		
+		Enrollment e = new Enrollment(id, new Schedule("Boosters"), "REMINDER", 
+				new DateTime(2012, 1, 1, 0, 0), new DateTime(2012, 1, 1, 0, 0), new Time(23,8), EnrollmentStatus.ACTIVE, null);
+		List<Action> alertActions = new ArrayList<Action>();
+		if(pushToOpenmrsForTest){
+			JSONObject p = ps.getPatientByIdentifier(id);
+			if(p == null){
+				ps.createPatient(new Client(id, "TEST", null, "Name", new DateTime().minusYears(20).toDate(), null, false, false, "MALE"));
+			}
+			JSONObject t = ss.createTrack(e, alertActions);
+			e.setStatus(EnrollmentStatus.COMPLETED);
+			Map<String, String> metadata = new HashMap<>();
+			metadata.put(OpenmrsConstants.ENROLLMENT_TRACK_UUID, t.getString("uuid"));
+			e.setMetadata(metadata );
+			ss.updateTrack(e, alertActions);
+		}
 	}
 	
-	private ActionData alert() {
-        return ActionData.createAlert(mother, "Ante Natal Care - Normal", "ANC 1", normal, DateTime.now(), DateTime.now().plusDays(3));
-    }
-
+	@Test
+	public void testTrackWithMilestoneAndWithoutAction() throws JSONException, ParseException {
+		String id = UUID.randomUUID().toString();
+		
+		Enrollment e = new Enrollment(id, new Schedule("Boosters"), "REMINDER", 
+				new DateTime(2012, 1, 1, 0, 0), new DateTime(2012, 1, 1, 0, 0), new Time(23,8), EnrollmentStatus.ACTIVE, null);
+		e.fulfillCurrentMilestone(new DateTime());
+		List<Action> alertActions = new ArrayList<Action>();
+		if(pushToOpenmrsForTest){
+			JSONObject p = ps.getPatientByIdentifier(id);
+			if(p == null){
+				ps.createPatient(new Client(id, "TEST", null, "Name", new DateTime().minusYears(20).toDate(), null, false, false, "MALE"));
+			}
+			JSONObject t = ss.createTrack(e, alertActions);
+			e.setStatus(EnrollmentStatus.COMPLETED);
+			Map<String, String> metadata = new HashMap<>();
+			metadata.put(OpenmrsConstants.ENROLLMENT_TRACK_UUID, t.getString("uuid"));
+			e.setMetadata(metadata );
+			ss.updateTrack(e, alertActions);
+		}
+	}
+	
+	@Test
+	public void testHHScheduleData() throws JSONException, ParseException, JsonIOException, IOException {
+		FormSubmission fs = getFormSubmissionFor("new_household_registration", 6);
+		
+		Client hhhead = oc.getClientFromFormSubmission(fs);
+		Event ev = oc.getEventFromFormSubmission(fs);
+		Map<String, Map<String, Object>> dep = oc.getDependentClientsFromFormSubmission(fs);
+		
+		OpenmrsHouseHold household = new OpenmrsHouseHold(hhhead, ev);
+		for (String hhmid : dep.keySet()) {
+			household.addHHMember((Client)dep.get(hhmid).get("client"), (Event)dep.get(hhmid).get("event"));
+		}
+		if(pushToOpenmrsForTest){
+			JSONObject pr = us.getProvider(fs.anmId());
+			if(pr == null){
+				us.createProvider(fs.anmId(), fs.anmId());
+			}
+			
+			JSONObject enct = es.getEncounterType(ev.getEventType());
+			if(enct == null){
+				es.createEncounterType(ev.getEventType(), "Encounter type created to fullfill scheduling test pre-reqs");
+			}
+			
+			for (String hhmid : dep.keySet()) {
+				Event ein = (Event)dep.get(hhmid).get("event");
+				JSONObject hmenct = es.getEncounterType(ein.getEventType());
+				if(hmenct == null){
+					es.createEncounterType(ein.getEventType(), "Encounter type created to fullfill scheduling test pre-reqs");
+				}
+			}
+			
+			hhs.saveHH(household, true);
+		}
+		
+		Enrollment e = new Enrollment(hhhead.getBaseEntityId(), new Schedule("FW CENSUS"), "FW CENSUS", 
+				new DateTime(), new DateTime(), new Time(23,8), EnrollmentStatus.ACTIVE, null);
+		List<Action> alertActions = new ArrayList<Action>();
+		alertActions.add(new Action(hhhead.getBaseEntityId(), ev.getProviderId(), alert("FW CENSUS", "FW CENSUS")));
+		if(pushToOpenmrsForTest){
+			JSONObject t = ss.createTrack(e, alertActions);
+			alertActions.add(new Action(hhhead.getBaseEntityId(), ev.getProviderId(), ActionData.markAlertAsClosed("FW CENSUS", "12-12-2015")));
+			e.setStatus(EnrollmentStatus.COMPLETED);
+			Map<String, String> metadata = new HashMap<>();
+			metadata.put(OpenmrsConstants.ENROLLMENT_TRACK_UUID, t.getString("uuid"));
+			e.setMetadata(metadata );
+			ss.updateTrack(e, alertActions);
+		}
+	}
+	
     private ActionData alert(String schedule, String milestone) {
         return ActionData.createAlert(mother, schedule, milestone, normal, DateTime.now(), DateTime.now().plusDays(3));
     }

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/PatientTest.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/PatientTest.java
@@ -5,7 +5,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
 
 import org.json.JSONException;
@@ -34,12 +33,15 @@ public class PatientTest extends TestResourceLoader{
 		addresses.add(new Address("BIRTH", new Date(), new Date(), null, "LAT", "LON", "PCODE", "SINDH", "PK"));
 		addresses.add(new Address("DEATH", new Date(), new Date(), null, "LATd", "LONd", "dPCODE", "KPK", "PK"));
 		Map<String, Object> attribs = new HashMap<>();
-		attribs.put("Household ID", "HH112");
+		//attribs.put("Household ID", "HH112");
 		Client c = new Client()
 			.withBaseEntity(new BaseEntity(UUID.randomUUID().toString(), "FN", "MN", "LN", new Date(), new Date(), 
 					true, false, "MALE", addresses , attribs ))
-			.withIdentifier("Birth Reg Num", "b-8912819"+new Random().nextInt(99))
-			.withIdentifier("Death Reg Num", "d-ewj-js3u2"+new Random().nextInt(99));
-		//System.out.println(s.createPatient(c));
+			//.withIdentifier("Birth Reg Num", "b-8912819"+new Random().nextInt(99))
+			//.withIdentifier("Death Reg Num", "d-ewj-js3u2"+new Random().nextInt(99))
+			;
+		if(pushToOpenmrsForTest){
+			System.out.println(s.createPatient(c));
+		}
 	}
 }

--- a/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/TestResourceLoader.java
+++ b/opensrp-connector/src/test/java/org/opensrp/connector/openmrs/service/TestResourceLoader.java
@@ -13,6 +13,7 @@ import org.springframework.core.io.support.PropertiesLoaderUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
+import com.mysql.jdbc.StringUtils;
 
 
 public class TestResourceLoader {
@@ -20,6 +21,8 @@ public class TestResourceLoader {
 	protected String openmrsUsername;
 	protected String openmrsPassword;
 	protected String formDirPath;
+	protected boolean pushToOpenmrsForTest;
+
 
 	public TestResourceLoader() throws IOException {
 		Resource resource = new ClassPathResource("/opensrp.properties");
@@ -28,6 +31,8 @@ public class TestResourceLoader {
 		openmrsUsername = props.getProperty("openmrs.username");
 		openmrsPassword = props.getProperty("openmrs.password");
 		formDirPath = props.getProperty("form.directory.name");
+		String rc = props.getProperty("openmrs.test.make-rest-call");
+		pushToOpenmrsForTest = StringUtils.isEmptyOrWhitespaceOnly(rc)?false:Boolean.parseBoolean(rc);
 	}
 	
 	protected FormSubmission getFormSubmissionFor(String formName, Integer number) throws JsonIOException, IOException{

--- a/opensrp-connector/src/test/resources/form/new_household_registration/form_definition.json
+++ b/opensrp-connector/src/test/resources/form/new_household_registration/form_definition.json
@@ -57,6 +57,10 @@
         "bind": "/model/instance/FWNewHH/FWHOHBIRTHDATE"
       },
       {
+        "name": "FWHOHBIRTHDATEAPPROX",
+        "bind": "/model/instance/FWNewHH/FWHOHBIRTHDATEAPPROX"
+      },
+      {
         "name": "FWHOHGENDER",
         "bind": "/model/instance/FWNewHH/FWHOHGENDER"
       },
@@ -118,6 +122,10 @@
           {
             "name": "FWBIRTHDATE",
             "bind": "/model/instance/FWNewHH/woman/FWBIRTHDATE"
+          },
+          {
+            "name": "FWBIRTHDATEAPPROX",
+            "bind": "/model/instance/FWNewHH/woman/FWBIRTHDATEAPPROX"
           },
           {
             "name": "FWGENDER",

--- a/opensrp-connector/src/test/resources/form/new_household_registration/form_submission6.json
+++ b/opensrp-connector/src/test/resources/form/new_household_registration/form_submission6.json
@@ -1,0 +1,206 @@
+{
+   "_id": "251ca0ef09df9af88f0e9d5f180115a3",
+   "_rev": "1-e73e1d93acdcdaeb1d41a738da5d9284",
+   "type": "FormSubmission",
+   "anmId": "admin",
+   "instanceId": "88c0e824-10b4-44c2-9429-754b8d823776",
+   "formName": "new_household_registration",
+   "entityId": "a3f2abf4-2699-4761-819a-cea739224164",
+   "clientVersion": 1430997074596,
+   "formDataDefinitionVersion": "1",
+   "formInstance": {
+       "form_data_definition_version": "1",
+       "form": {
+           "bind_type": "household",
+           "default_bind_path": "/model/instance/FWNewHH",
+           "fields": [
+               {
+                   "name": "id",
+                   "value": "a3f2abf4-2699-4761-819a-cea739224164",
+                   "source": "household.id"
+               },
+               {
+                   "name": "existing_location",
+                   "value": "KUPTALA",
+                   "source": "household.existing_location"
+               },
+               {
+                   "name": "today",
+                   "value": "2015-05-07",
+                   "source": "household.today"
+               },
+               {
+                   "name": "start",
+                   "value": "2015-05-07T17:07:21.000+06:00",
+                   "source": "household.start"
+               },
+               {
+                   "name": "end",
+                   "value": "2015-05-07T17:07:21.000+06:00",
+                   "source": "household.end"
+               },
+               {
+                   "name": "FWNHREGDATE",
+                   "value": "2015-05-07",
+                   "source": "household.FWNHREGDATE"
+               },
+               {
+                   "name": "FWGOBHHID",
+                   "value": "1234",
+                   "source": "household.FWGOBHHID"
+               },
+               {
+                   "name": "FWJIVHHID",
+                   "value": "1234",
+                   "source": "household.FWJIVHHID"
+               },
+               {
+                   "name": "FWNHNEARTO",
+                   "value": "nothing",
+                   "source": "household.FWNHNEARTO"
+               },
+               {
+                   "name": "FWNHHHGPS",
+                   "value": "34 34 0 0",
+                   "source": "household.FWNHHHGPS"
+               },
+               {
+                   "name": "FWHOHFNAME",
+                   "value": "test",
+                   "source": "household.FWHOHFNAME"
+               },
+               {
+                   "name": "FWHOHLNAME",
+                   "value": ".",
+                   "source": "household.FWHOHLNAME"
+               },
+               {
+                   "name": "FWHOHBIRTHDATE",
+                   "value": "1900-01-01",
+                   "source": "household.FWHOHBIRTHDATE"
+               },
+               {
+                   "name": "FWHOHGENDER",
+                   "value": "male",
+                   "source": "household.FWHOHGENDER"
+               },
+               {
+                   "name": "FWNHHMBRNUM",
+                   "source": "household.FWNHHMBRNUM"
+               },
+               {
+                   "name": "FWNHHMWRA",
+                   "source": "household.FWNHHMWRA"
+               },
+               {
+                   "name": "join_names",
+                   "value": "shumi sumaita",
+                   "source": "household.join_names"
+               },
+               {
+                   "name": "MWRA",
+                   "source": "household.MWRA"
+               }
+           ],
+           "sub_forms": [
+               {
+                   "name": "elco_registration",
+                   "bind_type": "elco",
+                   "default_bind_path": "/model/instance/FWNewHH/woman",
+                   "fields": [
+                       {
+                           "name": "id",
+                           "source": "elco.id"
+                       },
+                       {
+                           "name": "GOBHHID",
+                           "source": "elco.GOBHHID"
+                       },
+                       {
+                           "name": "JiVitAHHID",
+                           "source": "elco.JiVitAHHID"
+                       },
+                       {
+                           "name": "FWWOMFNAME",
+                           "source": "elco.FWWOMFNAME"
+                       },
+                       {
+                           "name": "FWWOMLNAME",
+                           "source": "elco.FWWOMLNAME"
+                       },
+                       {
+                           "name": "FWWOMNID",
+                           "source": "elco.FWWOMNID"
+                       },
+                       {
+                           "name": "FWWOMBID",
+                           "source": "elco.FWWOMBID"
+                       },
+                       {
+                           "name": "FWHUSNAME",
+                           "source": "elco.FWHUSNAME"
+                       },
+                       {
+                           "name": "FWBIRTHDATE",
+                           "source": "elco.FWBIRTHDATE"
+                       },
+                       {
+                           "name": "FWGENDER",
+                           "source": "elco.FWGENDER"
+                       },
+                       {
+                           "name": "FWWOMAGE",
+                           "source": "elco.FWWOMAGE"
+                       },
+                       {
+                           "name": "display_age",
+                           "source": "elco.display_age"
+                       },
+                       {
+                           "name": "FWNHWOMSTRMEN",
+                           "source": "elco.FWNHWOMSTRMEN"
+                       },
+                       {
+                           "name": "FWNHWOMHUSALV",
+                           "source": "elco.FWNHWOMHUSALV"
+                       },
+                       {
+                           "name": "FWNHWOMHUSLIV",
+                           "source": "elco.FWNHWOMHUSLIV"
+                       },
+                       {
+                           "name": "FWNHWOMHUSSTR",
+                           "source": "elco.FWNHWOMHUSSTR"
+                       },
+                       {
+                           "name": "FWELIGIBLE",
+                           "source": "elco.FWELIGIBLE"
+                       }
+                   ],
+                   "instances": [
+                       {
+                           "GOBHHID": "48374",
+                           "JiVitAHHID": "78748",
+                           "FWWOMFNAME": "tEST First",
+                           "FWWOMLNAME": " lastname",
+                           "FWWOMNID": "",
+                           "FWWOMBID": "",
+                           "FWHUSNAME": "",
+                           "FWBIRTHDATE": "2000-05-07",
+                           "FWGENDER": "Female",
+                           "FWWOMAGE": "",
+                           "display_age": "",
+                           "FWNHWOMSTRMEN": "",
+                           "FWNHWOMHUSALV": "",
+                           "FWNHWOMHUSLIV": "",
+                           "FWNHWOMHUSSTR": "",
+                           "FWELIGIBLE": "",
+                           "id": "babcd9d2-b3e9-4f6d-8a06-2df8f5fbf01f"
+                       }
+                   ]
+               }
+           ]
+       }
+   },
+   "serverVersion": 1430998001293
+}

--- a/opensrp-connector/src/test/resources/form/new_household_registration/form_submission7.json
+++ b/opensrp-connector/src/test/resources/form/new_household_registration/form_submission7.json
@@ -196,7 +196,7 @@
                            "FWWOMBID": "",
                            "FWHUSNAME": "",
                            "FWBIRTHDATE": "2000-05-07",
-                           "FWBIRTHDATEAPPROX":"1",
+                           "FWBIRTHDATEAPPROX":"0",
                            "FWGENDER": "Female",
                            "FWWOMAGE": "",
                            "display_age": "",

--- a/opensrp-connector/src/test/resources/form/new_household_registration/form_submission8.json
+++ b/opensrp-connector/src/test/resources/form/new_household_registration/form_submission8.json
@@ -80,11 +80,6 @@
                    "source": "household.FWHOHBIRTHDATE"
                },
                {
-                   "name": "FWHOHBIRTHDATEAPPROX",
-                   "value": "1",
-                   "source": "household.FWHOHBIRTHDATEAPPROX"
-               },
-               {
                    "name": "FWHOHGENDER",
                    "value": "male",
                    "source": "household.FWHOHGENDER"
@@ -196,7 +191,7 @@
                            "FWWOMBID": "",
                            "FWHUSNAME": "",
                            "FWBIRTHDATE": "2000-05-07",
-                           "FWBIRTHDATEAPPROX":"1",
+                           "FWBIRTHDATEAPPROX":"",
                            "FWGENDER": "Female",
                            "FWWOMAGE": "",
                            "display_age": "",

--- a/opensrp-connector/src/test/resources/form/new_household_registration/model.xml
+++ b/opensrp-connector/src/test/resources/form/new_household_registration/model.xml
@@ -16,7 +16,8 @@
             <FWHOHFNAME openmrs_entity="person" openmrs_entity_id="first_name"/>
             <FWHOHLNAME openmrs_entity="person" openmrs_entity_id="last_name"/>
             <FWHOHBIRTHDATE openmrs_entity="person" openmrs_entity_id="birthdate"/>
-            <FWHOHGENDER openmrs_entity="person" openmrs_entity_id="gender"/>
+            <FWHOHBIRTHDATE openmrs_entity="person" openmrs_entity_id="birthdate"/>
+            <FWHOHBIRTHDATEAPPROX openmrs_entity="person" openmrs_entity_id="birthdate_estimated"/>
             <FWNHHMBRNUM openmrs_entity="concept" openmrs_entity_id="5611AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
             <FWNHHMWRA/>
             <woman template="" openmrs_entity="person" openmrs_entity_id="Census and New Woman Registration">
@@ -28,6 +29,7 @@
                 <FWWOMBID openmrs_entity="person_identifier" openmrs_entity_id="Birth Registration ID"/>
                 <FWHUSNAME openmrs_entity="concept" openmrs_entity_id="161135AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
                 <FWBIRTHDATE openmrs_entity="person" openmrs_entity_id="birthdate"/>
+            	<FWBIRTHDATEAPPROX openmrs_entity="person" openmrs_entity_id="birthdate_estimated"/>
                 <FWGENDER openmrs_entity="person" openmrs_entity_id="gender"/>
                 <FWWOMAGE/>
                 <display_age/>

--- a/opensrp-connector/src/test/resources/form/new_household_registration/model.xml
+++ b/opensrp-connector/src/test/resources/form/new_household_registration/model.xml
@@ -32,7 +32,7 @@
                 <FWWOMAGE/>
                 <display_age/>
                 <FWNHWOMSTRMEN/>
-                <FWNHWOMHUSLIV openmrs_entity="concept" openmrs_entity_id="162849AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+                <FWNHWOMHUSLIV/>
                 <FWNHWOMHUSSTR/>
                 <FWELIGIBLE/>
                 <add_women/>

--- a/opensrp-core/src/main/java/org/opensrp/domain/AppStateToken.java
+++ b/opensrp-core/src/main/java/org/opensrp/domain/AppStateToken.java
@@ -49,27 +49,27 @@ public class AppStateToken extends MotechBaseDataObject {
 		return value;
 	}
 	
-	public long getLongValue() {
+	public long longValue() {
 		return Long.parseLong(value.toString());
 	}
 	
-	public int getIntValue() {
+	public int intValue() {
 		return Integer.parseInt(value.toString());
 	}
 	
-	public float getFloatValue() {
+	public float floatValue() {
 		return Float.parseFloat(value.toString());
 	}
 	
-	public double getDoubleValue() {
+	public double doubleValue() {
 		return Double.parseDouble(value.toString());
 	}
 	
-	public String getStringValue() {
+	public String stringValue() {
 		return value.toString();
 	}
 	
-	public boolean getBooleanValue() {
+	public boolean booleanValue() {
 		return Boolean.parseBoolean(value.toString());
 	}
 	

--- a/opensrp-core/src/main/java/org/opensrp/domain/AppStateToken.java
+++ b/opensrp-core/src/main/java/org/opensrp/domain/AppStateToken.java
@@ -1,0 +1,110 @@
+package org.opensrp.domain;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.ektorp.support.TypeDiscriminator;
+import org.motechproject.model.MotechBaseDataObject;
+
+@TypeDiscriminator("doc.type === 'AppStateToken'")
+public class AppStateToken extends MotechBaseDataObject {
+    @JsonProperty
+    private String name;
+    
+    @JsonProperty
+    private Object value;
+    
+    @JsonProperty
+    private long lastEditDate;
+    
+    @JsonProperty
+    private String description;
+
+    protected AppStateToken() {
+    }
+
+    public AppStateToken(String name, Object value, long lastEditDate) {
+		this.name = name;
+		this.value = value;
+		this.lastEditDate = lastEditDate;
+	}
+
+	public AppStateToken(String name, Object value, long lastEditDate, String description) {
+		this.name = name;
+		this.value = value;
+		this.lastEditDate = lastEditDate;
+		this.description = description;
+	}
+
+    public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+	
+	public long getLongValue() {
+		return Long.parseLong(value.toString());
+	}
+	
+	public int getIntValue() {
+		return Integer.parseInt(value.toString());
+	}
+	
+	public float getFloatValue() {
+		return Float.parseFloat(value.toString());
+	}
+	
+	public double getDoubleValue() {
+		return Double.parseDouble(value.toString());
+	}
+	
+	public String getStringValue() {
+		return value.toString();
+	}
+	
+	public boolean getBooleanValue() {
+		return Boolean.parseBoolean(value.toString());
+	}
+	
+	public void setValue(Object value) {
+		this.value = value;
+	}
+
+	public long getLastEditDate() {
+		return lastEditDate;
+	}
+
+	public void setLastEditDate(long lastEditDate) {
+		this.lastEditDate = lastEditDate;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this, "id");
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/opensrp-core/src/main/java/org/opensrp/repository/AllAppStateTokens.java
+++ b/opensrp-core/src/main/java/org/opensrp/repository/AllAppStateTokens.java
@@ -1,0 +1,25 @@
+package org.opensrp.repository;
+
+import java.util.List;
+
+import org.ektorp.CouchDbConnector;
+import org.ektorp.support.GenerateView;
+import org.motechproject.dao.MotechBaseRepository;
+import org.opensrp.common.AllConstants;
+import org.opensrp.domain.AppStateToken;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AllAppStateTokens extends MotechBaseRepository<AppStateToken> {
+    @Autowired
+    protected AllAppStateTokens(@Qualifier(AllConstants.OPENSRP_DATABASE_CONNECTOR) CouchDbConnector db) {
+        super(AppStateToken.class, db);
+    }
+    
+    @GenerateView
+	public List<AppStateToken> findByName(String name) {
+    	return queryView("by_name", name);
+	}
+}

--- a/opensrp-core/src/main/java/org/opensrp/scheduler/repository/AllActions.java
+++ b/opensrp-core/src/main/java/org/opensrp/scheduler/repository/AllActions.java
@@ -9,6 +9,7 @@ import org.ektorp.ComplexKey;
 import org.ektorp.CouchDbConnector;
 import org.ektorp.support.GenerateView;
 import org.ektorp.support.View;
+import org.joda.time.DateTime;
 import org.motechproject.dao.MotechBaseRepository;
 import org.opensrp.common.AllConstants;
 import org.opensrp.scheduler.Action;
@@ -44,6 +45,13 @@ public class AllActions extends MotechBaseRepository<Action> {
         return db.queryView(createQuery("action_by_anm_entityId_scheduleName").key(key).includeDocs(true), Action.class);
     }
 
+    @View(name = "action_by_caseId_and_schedule_and_time", map = "function(doc) { if (doc.type === 'Action') { emit([doc.caseID, doc.data.scheduleName, doc.timeStamp], null); } }")
+    public List<Action> findByCaseIdScheduleAndTimeStamp(String caseId, String schedule, DateTime start, DateTime end) {
+        ComplexKey startKey = ComplexKey.of(caseId, schedule, start.getMillis() + 1);
+        ComplexKey endKey = ComplexKey.of(caseId, schedule, end.getMillis());
+        return db.queryView(createQuery("action_by_caseId_and_schedule_and_time").startKey(startKey).endKey(endKey).includeDocs(true), Action.class);
+    }
+    
     public void deleteAllByTarget(String target) {
         deleteAll(findByActionTarget(target));
     }

--- a/opensrp-core/src/main/java/org/opensrp/scheduler/service/ActionService.java
+++ b/opensrp-core/src/main/java/org/opensrp/scheduler/service/ActionService.java
@@ -27,6 +27,10 @@ public class ActionService {
     public List<Action> getNewAlertsForANM(String anmIdentifier, long timeStamp) {
         return allActions.findByANMIDAndTimeStamp(anmIdentifier, timeStamp);
     }
+    
+    public List<Action> findByCaseIdScheduleAndTimeStamp(String caseId, String schedule, DateTime start, DateTime end) {
+		return allActions.findByCaseIdScheduleAndTimeStamp(caseId, schedule, start, end);
+	}
 
     public void alertForBeneficiary(BeneficiaryType beneficiaryType, String caseID, String anmIdentifier, String scheduleName, String visitCode, AlertStatus alertStatus, DateTime startDate, DateTime expiryDate) {
     	if (!(mother.equals(beneficiaryType)||child.equals(beneficiaryType)||ec.equals(beneficiaryType))) {

--- a/opensrp-core/src/main/java/org/opensrp/scheduler/service/AllEnrollmentWrapper.java
+++ b/opensrp-core/src/main/java/org/opensrp/scheduler/service/AllEnrollmentWrapper.java
@@ -23,22 +23,31 @@ class AllEnrollmentWrapper extends AllEnrollments{
 		super(db);
 	}
 
-	 private static final String FUNCTION_DOC_EMIT_DOC_STATUS_AND_ENROLLED_ON = "function(doc) { if(doc.type === 'Enrollment') emit([doc.status,doc.enrolledOn], doc._id);}";
+	private static final String FUNCTION_DOC_EMIT_DOC_STATUS_AND_ENROLLED_ON = "function(doc) { if(doc.type === 'Enrollment') emit([doc.status,doc.enrolledOn], doc._id);}";
 
-	    @View(name = "by_status_date_enrolled", map = FUNCTION_DOC_EMIT_DOC_STATUS_AND_ENROLLED_ON)
-	    public List<Enrollment> findByEnrollmentDate(String status, DateTime start, DateTime end) {
-	        List<Enrollment> enrollments = queryView("by_status_date_enrolled", ComplexKey.of(status, start, end));
-	        return populateWithSchedule(enrollments);
-	    }
-	    
-	    private List<Enrollment> populateWithSchedule(List<Enrollment> enrollments) {
-	        for (Enrollment enrollment : enrollments)
-	            populateSchedule(enrollment);
-	        return enrollments;
-	    }
+    @View(name = "by_status_date_enrolled", map = FUNCTION_DOC_EMIT_DOC_STATUS_AND_ENROLLED_ON)
+    public List<Enrollment> findByEnrollmentDate(String status, DateTime start, DateTime end) {
+        List<Enrollment> enrollments = queryView("by_status_date_enrolled", ComplexKey.of(status, start, end));
+        return populateWithSchedule(enrollments);
+    }
 
-	    private Enrollment populateSchedule(Enrollment enrollment) {
-	        enrollment.setSchedule(allSchedules.getByName(enrollment.getScheduleName()));
-	        return enrollment;
-	    }
+    private static final String FUNCTION_DOC_EMIT_LAST_UPDATE = "function(doc) { if(doc.type === 'Enrollment') emit([doc.metadata.lastUpdate], doc._id);}";
+    
+    @View(name = "by_last_update", map = FUNCTION_DOC_EMIT_LAST_UPDATE)
+    public List<Enrollment> findByLastUpDate(DateTime start, DateTime end) {
+    	List<Enrollment> enrollments = queryView("by_last_update", ComplexKey.of(start, end));
+    	return populateWithSchedule(enrollments);
+    }
+    
+    private List<Enrollment> populateWithSchedule(List<Enrollment> enrollments) {
+        for (Enrollment enrollment : enrollments)
+            populateSchedule(enrollment);
+        return enrollments;
+    }
+
+    private Enrollment populateSchedule(Enrollment enrollment) {
+        enrollment.setSchedule(allSchedules.getByName(enrollment.getScheduleName()));
+        return enrollment;
+    }
+    
 }

--- a/opensrp-core/src/main/java/org/opensrp/scheduler/service/AllEnrollmentWrapper.java
+++ b/opensrp-core/src/main/java/org/opensrp/scheduler/service/AllEnrollmentWrapper.java
@@ -27,15 +27,17 @@ class AllEnrollmentWrapper extends AllEnrollments{
 
     @View(name = "by_status_date_enrolled", map = FUNCTION_DOC_EMIT_DOC_STATUS_AND_ENROLLED_ON)
     public List<Enrollment> findByEnrollmentDate(String status, DateTime start, DateTime end) {
-        List<Enrollment> enrollments = queryView("by_status_date_enrolled", ComplexKey.of(status, start, end));
+    	ComplexKey s = ComplexKey.of(status, start);
+    	ComplexKey e = ComplexKey.of(status, end);
+        List<Enrollment> enrollments = db.queryView(createQuery("by_status_date_enrolled").startKey(s).endKey(e).includeDocs(true), Enrollment.class);
         return populateWithSchedule(enrollments);
     }
 
-    private static final String FUNCTION_DOC_EMIT_LAST_UPDATE = "function(doc) { if(doc.type === 'Enrollment') emit([doc.metadata.lastUpdate], doc._id);}";
+    private static final String FUNCTION_DOC_EMIT_LAST_UPDATE = "function(doc) { if(doc.type === 'Enrollment') emit(doc.metadata.lastUpdate, doc._id);}";
     
     @View(name = "by_last_update", map = FUNCTION_DOC_EMIT_LAST_UPDATE)
     public List<Enrollment> findByLastUpDate(DateTime start, DateTime end) {
-    	List<Enrollment> enrollments = queryView("by_last_update", ComplexKey.of(start, end));
+        List<Enrollment> enrollments = db.queryView(createQuery("by_last_update").startKey(start).endKey(end).includeDocs(true), Enrollment.class);
     	return populateWithSchedule(enrollments);
     }
     

--- a/opensrp-core/src/main/java/org/opensrp/scheduler/service/AllEnrollmentWrapper.java
+++ b/opensrp-core/src/main/java/org/opensrp/scheduler/service/AllEnrollmentWrapper.java
@@ -1,0 +1,44 @@
+package org.opensrp.scheduler.service;
+
+import java.util.List;
+
+import org.ektorp.ComplexKey;
+import org.ektorp.CouchDbConnector;
+import org.ektorp.support.View;
+import org.joda.time.DateTime;
+import org.motechproject.scheduletracking.api.domain.Enrollment;
+import org.motechproject.scheduletracking.api.repository.AllEnrollments;
+import org.motechproject.scheduletracking.api.repository.AllSchedules;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+@Repository
+class AllEnrollmentWrapper extends AllEnrollments{
+	@Autowired
+    private AllSchedules allSchedules;
+	
+	@Autowired
+	public AllEnrollmentWrapper(@Qualifier("scheduleTrackingDbConnector") CouchDbConnector db) {
+		super(db);
+	}
+
+	 private static final String FUNCTION_DOC_EMIT_DOC_STATUS_AND_ENROLLED_ON = "function(doc) { if(doc.type === 'Enrollment') emit([doc.status,doc.enrolledOn], doc._id);}";
+
+	    @View(name = "by_status_date_enrolled", map = FUNCTION_DOC_EMIT_DOC_STATUS_AND_ENROLLED_ON)
+	    public List<Enrollment> findByEnrollmentDate(String status, DateTime start, DateTime end) {
+	        List<Enrollment> enrollments = queryView("by_status_date_enrolled", ComplexKey.of(status, start, end));
+	        return populateWithSchedule(enrollments);
+	    }
+	    
+	    private List<Enrollment> populateWithSchedule(List<Enrollment> enrollments) {
+	        for (Enrollment enrollment : enrollments)
+	            populateSchedule(enrollment);
+	        return enrollments;
+	    }
+
+	    private Enrollment populateSchedule(Enrollment enrollment) {
+	        enrollment.setSchedule(allSchedules.getByName(enrollment.getScheduleName()));
+	        return enrollment;
+	    }
+}

--- a/opensrp-core/src/main/java/org/opensrp/scheduler/service/ScheduleService.java
+++ b/opensrp-core/src/main/java/org/opensrp/scheduler/service/ScheduleService.java
@@ -9,9 +9,11 @@ import static org.opensrp.common.util.DateUtil.today;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 import org.motechproject.model.Time;
+import org.motechproject.scheduletracking.api.domain.Enrollment;
 import org.motechproject.scheduletracking.api.domain.Milestone;
 import org.motechproject.scheduletracking.api.domain.Schedule;
 import org.motechproject.scheduletracking.api.repository.AllSchedules;
@@ -27,13 +29,16 @@ import org.springframework.stereotype.Service;
 public class ScheduleService {
     private final ScheduleTrackingService scheduleTrackingService;
     private final AllSchedules allSchedules;
+    private final AllEnrollmentWrapper allEnrollments;
     private int preferredTime;
 
     @Autowired
-    public ScheduleService(ScheduleTrackingService scheduleTrackingService, AllSchedules allSchedules, @Value("#{opensrp['preferred.time']}") int preferredTime) {
+    public ScheduleService(ScheduleTrackingService scheduleTrackingService, AllSchedules allSchedules, 
+    		@Value("#{opensrp['preferred.time']}") int preferredTime, AllEnrollmentWrapper allEnrollments) {
         this.scheduleTrackingService = scheduleTrackingService;
         this.allSchedules = allSchedules;
         this.preferredTime = preferredTime;
+        this.allEnrollments = allEnrollments;
     }
 
     public void enroll(String entityId, String scheduleName, String referenceDate) {
@@ -74,6 +79,16 @@ public class ScheduleService {
         return scheduleTrackingService.search(new EnrollmentsQuery().havingExternalId(entityId).havingState(ACTIVE));
 	}
     
+    public List<Enrollment> findEnrollmentByStatusAndEnrollmentDate(String status, DateTime start, DateTime end) {
+        return allEnrollments.findByEnrollmentDate(status, start, end);
+	}
+    
+    public void updateEnrollmentWithMetadata(String enrollmentId, String key, String value) {
+    	Enrollment e = allEnrollments.get(enrollmentId);
+    	e.getMetadata().put(key, value);
+    	allEnrollments.update(e);
+
+	}
     public List<String> findOpenEnrollmentNames(String entityId) {
     	List<EnrollmentRecord> openEnrollments = findOpenEnrollments(entityId);
     	List<String> openSchedules = new ArrayList<>();

--- a/opensrp-core/src/main/java/org/opensrp/service/ConfigService.java
+++ b/opensrp-core/src/main/java/org/opensrp/service/ConfigService.java
@@ -1,0 +1,72 @@
+package org.opensrp.service;
+
+import java.util.List;
+
+import org.opensrp.domain.AppStateToken;
+import org.opensrp.repository.AllAppStateTokens;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.mysql.jdbc.StringUtils;
+
+@Service
+public class ConfigService {
+	
+	private final AllAppStateTokens allAppStateTokens;
+	
+	@Autowired
+	public ConfigService(AllAppStateTokens allAppStateTokens)
+	{
+		this.allAppStateTokens = allAppStateTokens;
+	}
+	
+	/**
+	 * @param tokenName
+	 * @return AppStateToken with given name. Since model is supposed to keep track of system`s state at any given time it throws IllegalStateException incase multiple Tokens found with same name.
+	 */
+	public AppStateToken getAppStateTokenByName(Enum<?> tokenName) {
+		List<AppStateToken> ol = allAppStateTokens.findByName(tokenName.name());
+		if(ol.size() > 1){
+			throw new IllegalStateException("System was found to have multiple token with same name ("+tokenName.name()+"). This can lead to potential critical inconsistencies.");
+		}
+		
+		return ol.size()==0?null:ol.get(0);
+	}
+	
+	public void updateAppStateToken(Enum<?> tokenName, Object value) {
+		List<AppStateToken> ol = allAppStateTokens.findByName(tokenName.name());
+		if(ol.size() > 1){
+			throw new IllegalStateException("System was found to have multiple token with same name ("+tokenName.name()+"). This can lead to potential critical inconsistencies.");
+		}
+		
+		if(ol.size() == 0){
+			throw new IllegalStateException("Property with name ("+tokenName.name()+") not found.");
+		}
+		
+		AppStateToken ast = ol.get(0);
+		ast.setValue(value);
+		ast.setLastEditDate(System.currentTimeMillis());
+		allAppStateTokens.update(ast);
+	}
+	
+	/** Registers a new token to manage the specified variable state (by token name) of App.
+	 * Throws IllegalArgumentException if tokenName or description is not provided or if name is not unique i.e. already exists in system.
+	 * @param tokenName
+	 * @param defaultValue
+	 * @param description
+	 * @return The newly registered token. 
+	 * 
+	 */
+	public AppStateToken registerAppStateToken(Enum<?> tokenName, Object defaultValue, String description) {
+		if(tokenName == null || StringUtils.isEmptyOrWhitespaceOnly(description)){
+			throw new IllegalArgumentException("Token name and description must be provided");
+		}
+		
+		if(allAppStateTokens.findByName(tokenName.name()) != null){
+			throw new IllegalArgumentException("Token with given name ("+tokenName.name()+") already exists.");
+		}
+		AppStateToken token = new AppStateToken(tokenName.name(), defaultValue, 0L, description);
+		allAppStateTokens.add(token);
+		return token;
+	}
+}

--- a/opensrp-core/src/main/java/org/opensrp/service/ConfigService.java
+++ b/opensrp-core/src/main/java/org/opensrp/service/ConfigService.java
@@ -62,7 +62,7 @@ public class ConfigService {
 			throw new IllegalArgumentException("Token name and description must be provided");
 		}
 		
-		if(allAppStateTokens.findByName(tokenName.name()) != null){
+		if(allAppStateTokens.findByName(tokenName.name()).size() > 0){
 			throw new IllegalArgumentException("Token with given name ("+tokenName.name()+") already exists.");
 		}
 		AppStateToken token = new AppStateToken(tokenName.name(), defaultValue, 0L, description);

--- a/opensrp-register/src/test/java/org/opensrp/register/service/scheduling/ScheduleServiceTest.java
+++ b/opensrp-register/src/test/java/org/opensrp/register/service/scheduling/ScheduleServiceTest.java
@@ -38,7 +38,7 @@ public class ScheduleServiceTest {
         schedule = new Schedule("my_schedule");
         schedule.addMilestones(firstMilestone);
         schedule.addMilestones(secondMilestone);
-        scheduleService = new ScheduleService(scheduleTrackingService, allSchedules, 14);
+        scheduleService = new ScheduleService(scheduleTrackingService, allSchedules, 14, null);
     }
 
     @Test

--- a/opensrp-web/src/main/java/org/opensrp/web/controller/FormSubmissionController.java
+++ b/opensrp-web/src/main/java/org/opensrp/web/controller/FormSubmissionController.java
@@ -127,40 +127,17 @@ public class FormSubmissionController {
                     return FormSubmissionConverter.toFormSubmission(submission);
                 }
             });
-            for (FormSubmission formSubmission : fsl) {
-            	
-            	 addFormToOpenMRS(formSubmission);
-            	
-            	 //this fucntionality is moved to addFormToOpenMRS();
-         /*   	if(openmrsConnector.isOpenmrsForm(formSubmission)){
-	            	JSONObject p = patientService.getPatientByIdentifier(formSubmission.entityId());
-	            	
-	            	if(p != null){	            		
-	            		Event e = openmrsConnector.getEventFromFormSubmission(formSubmission);
-		        		System.out.println(encounterService.createEncounter(e));
+	            for (FormSubmission formSubmission : fsl) {
+	            	try{
+	            		addFormToOpenMRS(formSubmission);
 	            	}
-	            	else {
-	            		Map<String, Map<String, Object>> dep = openmrsConnector.getDependentClientsFromFormSubmission(formSubmission);
-	            		
-	            		if(dep.size()>0){
-	            			Client hhhClient = openmrsConnector.getClientFromFormSubmission(formSubmission);
-	            			Event hhhEvent = openmrsConnector.getEventFromFormSubmission(formSubmission);
-	            			OpenmrsHouseHold hh = new OpenmrsHouseHold(hhhClient, hhhEvent);
-	    	    			for (Map<String, Object> cm : dep.values()) {
-	    	    				hh.addHHMember((Client)cm.get("client"), (Event)cm.get("event"));
-	    	    			}
-	    	    			
-	    	    			householdService.saveHH(hh);
-	            		}
-	            		else {
-	            			Client c = openmrsConnector.getClientFromFormSubmission(formSubmission);
-	            			System.out.println(patientService.createPatient(c));
-	            			Event e = openmrsConnector.getEventFromFormSubmission(formSubmission);
-			        		System.out.println(encounterService.createEncounter(e));
-	            		}
+	            	catch(Exception e){
+	            		e.printStackTrace();
+	            		ErrorTrace errorTrace=new ErrorTrace(new Date(), "Parse Exception", "", e.getStackTrace().toString(), "Unsolved", formSubmission.formName());
+						errorTrace.setRecordId(formSubmission.instanceId());
+						errorTraceService.addError(errorTrace);
 	            	}
-            	}*/
-    		}
+	    		}
             }
             catch(Exception e){
             	e.printStackTrace();
@@ -173,78 +150,41 @@ public class FormSubmissionController {
         return new ResponseEntity<>(CREATED);
     }
     
-    private void addFormToOpenMRS(FormSubmission formSubmission){
+    private void addFormToOpenMRS(FormSubmission formSubmission) throws ParseException, JSONException{
     	if(openmrsConnector.isOpenmrsForm(formSubmission)){
-        	JSONObject p = null;
-			try {
-				p = patientService.getPatientByIdentifier(formSubmission.entityId());
-			} catch (JSONException e1) {
-				
-				ErrorTrace errorTrace=new ErrorTrace(new Date(), "JSON Exception", "", e1.getStackTrace().toString(), "Unsolved", formSubmission.formName());
-				errorTrace.setRecordId(formSubmission.instanceId());
-				e1.printStackTrace();
-			}
+    		Client c = openmrsConnector.getClientFromFormSubmission(formSubmission);
+			Event e = openmrsConnector.getEventFromFormSubmission(formSubmission);
+			Map<String, Map<String, Object>> dep = openmrsConnector.getDependentClientsFromFormSubmission(formSubmission);
+
+    		// TODO temporary because not necessarily we register inner entity for Household only
+    		if(formSubmission.formName().toLowerCase().contains("household") 
+    				|| formSubmission.formName().toLowerCase().contains("census") ){
+    			OpenmrsHouseHold hh = new OpenmrsHouseHold(c, e);
+    			for (Map<String, Object> cm : dep.values()) {
+    				hh.addHHMember((Client)cm.get("client"), (Event)cm.get("event"));
+    			}
+    			
+    			householdService.saveHH(hh, true);
+    		}
+    		else {
+    			JSONObject p = patientService.getPatientByIdentifier(c.getBaseEntityId());
+    			if(p == null){
+    				System.out.println(patientService.createPatient(c));
+    			}
         	
-        	if(p != null){	            		
-        		Event e;
-				try {
-					e = openmrsConnector.getEventFromFormSubmission(formSubmission);
-					System.out.println(encounterService.createEncounter(e));
-				} catch (ParseException e1) {
-				
-					ErrorTrace errorTrace=new ErrorTrace(new Date(), "Parse Exception", "", e1.getStackTrace().toString(), "Unsolved", formSubmission.formName());
-					errorTrace.setRecordId(formSubmission.instanceId());
-					//errorTrace
-					errorTraceService.addError(errorTrace);
-					e1.printStackTrace();
-				} catch (JSONException e1) {
-				
-					ErrorTrace errorTrace=new ErrorTrace(new Date(), "JSON Exception", "", e1.getStackTrace().toString(), "Unsolved", formSubmission.formName());
-					errorTrace.setRecordId(formSubmission.instanceId());
-					errorTraceService.addError(errorTrace);
-					e1.printStackTrace();
-				}
-        		
-        	}
-        	else {
-        		Map<String, Map<String, Object>> dep;
-				try {
-					dep = openmrsConnector.getDependentClientsFromFormSubmission(formSubmission);
-					if(dep.size()>0){
-	        			Client hhhClient = openmrsConnector.getClientFromFormSubmission(formSubmission);
-	        			Event hhhEvent = openmrsConnector.getEventFromFormSubmission(formSubmission);
-	        			OpenmrsHouseHold hh = new OpenmrsHouseHold(hhhClient, hhhEvent);
-		    			for (Map<String, Object> cm : dep.values()) {
-		    				hh.addHHMember((Client)cm.get("client"), (Event)cm.get("event"));
-		    			}
-		    			
-		    			householdService.saveHH(hh);
-				}
-					else {
-	        			Client c = openmrsConnector.getClientFromFormSubmission(formSubmission);
-	        			System.out.println(patientService.createPatient(c));
-	        			Event e = openmrsConnector.getEventFromFormSubmission(formSubmission);
-		        		System.out.println(encounterService.createEncounter(e));
-	        		}
-				
-				
-        	}catch (ParseException e1) {
-        		ErrorTrace errorTrace=new ErrorTrace(new Date(), "Parse Exception", "", e1.getStackTrace().toString(), "Unsolved", formSubmission.formName());
-        		errorTrace.setRecordId(formSubmission.instanceId());
-        		errorTraceService.addError(errorTrace);
-        		e1.printStackTrace();
-			} catch (JSONException e) {
-			
-				ErrorTrace errorTrace=new ErrorTrace(new Date(), "JSON Exception", "", e.getStackTrace().toString(), "Unsolved", formSubmission.formName());
-				errorTrace.setRecordId(formSubmission.instanceId());
-				errorTraceService.addError(errorTrace);
-				e.printStackTrace();
-			}
-        	
-        	}
-        		
-        	
+    			System.out.println(encounterService.createEncounter(e));
+    			
+    			for (Map<String, Object> cm : dep.values()) {
+    				Client cin = (Client)cm.get("client");
+    				Event evin = (Event)cm.get("event");
+    				JSONObject pin = patientService.getPatientByIdentifier(cin.getBaseEntityId());
+        			if(pin == null){
+        				System.out.println(patientService.createPatient(cin));
+        			}
+            	
+        			System.out.println(encounterService.createEncounter(evin));
+    			}
+    		}
     	}
-    	
     }
 }

--- a/opensrp-web/src/main/java/org/opensrp/web/listener/ApplicationStartupListener.java
+++ b/opensrp-web/src/main/java/org/opensrp/web/listener/ApplicationStartupListener.java
@@ -2,6 +2,7 @@ package org.opensrp.web.listener;
 
 import java.util.concurrent.TimeUnit;
 
+import org.opensrp.connector.openmrs.constants.OpenmrsConstants;
 import org.opensrp.register.DrishtiScheduleConstants;
 import org.opensrp.scheduler.RepeatingSchedule;
 import org.opensrp.scheduler.TaskSchedulerService;
@@ -20,15 +21,18 @@ public class ApplicationStartupListener implements ApplicationListener<ContextRe
     private RepeatingSchedule formSchedule;
     private RepeatingSchedule anmReportScheduler;
     private RepeatingSchedule mctsReportScheduler;
+    private RepeatingSchedule openmrsScheduleSyncerScheduler;
     
     @Autowired
     public ApplicationStartupListener(TaskSchedulerService scheduler, 
     		@Value("#{opensrp['form.poll.time.interval']}") int formPollInterval,
-    		@Value("#{opensrp['mcts.poll.time.interval.in.minutes']}") int mctsPollIntervalInHours) {
+    		@Value("#{opensrp['mcts.poll.time.interval.in.minutes']}") int mctsPollIntervalInHours,
+    		@Value("#{opensrp['openmrs.scheduletracker.syncer.interval-min']}") int openmrsSchSyncerMin) {
         this.scheduler = scheduler;
         formSchedule = new RepeatingSchedule(DrishtiScheduleConstants.FORM_SCHEDULE_SUBJECT, 2, TimeUnit.MINUTES, formPollInterval, TimeUnit.MINUTES);
         anmReportScheduler = new RepeatingSchedule(DrishtiScheduleConstants.ANM_REPORT_SCHEDULE_SUBJECT, 10, TimeUnit.MINUTES, 6, TimeUnit.HOURS);
         mctsReportScheduler = new RepeatingSchedule(DrishtiScheduleConstants.MCTS_REPORT_SCHEDULE_SUBJECT, 10, TimeUnit.MINUTES, mctsPollIntervalInHours, TimeUnit.HOURS);
+        openmrsScheduleSyncerScheduler = new RepeatingSchedule(OpenmrsConstants.SCHEDULER_TRACKER_SYNCER_SUBJECT, 2, TimeUnit.MINUTES, openmrsSchSyncerMin, TimeUnit.MINUTES);
     }
 
     @Override
@@ -37,6 +41,7 @@ public class ApplicationStartupListener implements ApplicationListener<ContextRe
             scheduler.startJob(formSchedule);
             scheduler.startJob(anmReportScheduler);
             scheduler.startJob(mctsReportScheduler);
+            scheduler.startJob(openmrsScheduleSyncerScheduler);
         }
     }
 }

--- a/opensrp-web/src/main/java/org/opensrp/web/listener/ApplicationStartupListener.java
+++ b/opensrp-web/src/main/java/org/opensrp/web/listener/ApplicationStartupListener.java
@@ -14,7 +14,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ApplicationStartupListener implements ApplicationListener<ContextRefreshedEvent> {
-    public static final String APPLICATION_ID = "org.springframework.web.context.WebApplicationContext:/opensrp";
+	public static final String APPLICATION_ID = "/opensrp";
+    public static final String APPLICATION_ID_FULL = "org.springframework.web.context.WebApplicationContext:"+APPLICATION_ID;
 
     private TaskSchedulerService scheduler;
     
@@ -37,11 +38,13 @@ public class ApplicationStartupListener implements ApplicationListener<ContextRe
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
-        if (APPLICATION_ID.equals(contextRefreshedEvent.getApplicationContext().getId())) {
+    	System.out.println(contextRefreshedEvent.getApplicationContext().getId());
+        if (contextRefreshedEvent.getApplicationContext().getId().endsWith(APPLICATION_ID)) {
             scheduler.startJob(formSchedule);
             scheduler.startJob(anmReportScheduler);
             scheduler.startJob(mctsReportScheduler);
             scheduler.startJob(openmrsScheduleSyncerScheduler);
+        	System.out.println("STARTED ALL SCHEDULES");
         }
     }
 }

--- a/releaseNotes.txt
+++ b/releaseNotes.txt
@@ -7,6 +7,7 @@ New Features
 - OpenMRS user service allows to get and create provide for test
 - Added a property to switch off/on the REST calls to OpenMRS from opensrp.properties to allow user choose whether to run integration test or not
 - SchduleTracker tested with HH schedule tests
+- Added provision to allow setting birthdate and deathdate approximation status from xlsform
 
 Changes
 =======

--- a/releaseNotes.txt
+++ b/releaseNotes.txt
@@ -1,39 +1,31 @@
-<<<<<<< HEAD
-Date of Release: 27-Jul-2015
+Date of Release: 18-Sep-2015
 
 New Features
 ============
-- Added javadoc for all important functions
-- Added testcase for empty repeat group handling
+- Added schedule tracker data sync that sync all enrollments keep updating if any changes occur later
+- A config manager added to handle system state at any point of time
+- OpenMRS user service allows to get and create provide for test
+- Added a property to switch off/on the REST calls to OpenMRS from opensrp.properties to allow user choose whether to run integration test or not
+- SchduleTracker tested with HH schedule tests
 
 Changes
 =======
 - Removed unnecessary and/or commented out code
+- Action repo and service was added a new method to fetch data by case, schedule, timestamp
+- Schedule syncer schedule added
+- Scheduletracker syncer property added
+- Allows to create Encounter Type for test
+- HHService for OpenMRS allows to switch the existing person ignore property. Now allows to update instead of creating new patient
+- Updated DB names to opensrp from drishti
+- FormSubmissionController in opensrp-web refactored to be optimized and to conform to saveHH method changes
 
 Fixes
 =====
-- Fixed a bug for wrong handling of entity parent id mapping of openmrs attributes in OpenmrsConnector
+- Removed part of addressTest causing test fail occasionally
+- Attributes list in BaseEntity in API would be instantiated automatically to prevent NPE
+- Check added in OpenMRS encounter create method to prevent NPE incase when no Obs is present in Event
+- HH Test wont throw exception for old MVP dictionary. Removed newer concepts from model.xml
+- Fixes for property methods, and couch queries
 
 Known Issues
 ============
-=======
-Date of Release: 23-Jun-2015
-
-New Features
-============
-- Added power mock api in pom to handle static class mocks
-
-Changes
-=======
-- Removed all calls to live server in connector tests and now using only mock objects and mock calls
-- Using mocks only instead of calls to server in opensrp web tests
-- Printing message in UserController when team member mapping fails instead of stacktrace as it is ignorable
-
-Fixes
-=====
-- Fixed the issue where code was assigning wrong ID to subform entities
-- 
-
-Known Issues
-============
->>>>>>> refs/remotes/origin/ErrorLogging


### PR DESCRIPTION
#68 

New Features
============
- Added schedule tracker data sync that sync all enrollments keep updating if any changes occur later
- A config manager added to handle system state at any point of time
- OpenMRS user service allows to get and create provide for test
- Added a property to switch off/on the REST calls to OpenMRS from opensrp.properties to allow user choose whether to run integration test or not
- SchduleTracker tested with HH schedule tests
- Added provision to allow setting birthdate and deathdate approximation status from xlsform

Changes
=======
- Removed unnecessary and/or commented out code
- Action repo and service was added a new method to fetch data by case, schedule, timestamp
- Schedule syncer schedule added
- Scheduletracker syncer property added
- Allows to create Encounter Type for test
- HHService for OpenMRS allows to switch the existing person ignore property. Now allows to update instead of creating new patient
- Updated DB names to opensrp from drishti
- FormSubmissionController in opensrp-web refactored to be optimized and to conform to saveHH method changes

Fixes
=====
- Removed part of addressTest causing test fail occasionally
- Attributes list in BaseEntity in API would be instantiated automatically to prevent NPE
- Check added in OpenMRS encounter create method to prevent NPE incase when no Obs is present in Event
- HH Test wont throw exception for old MVP dictionary. Removed newer concepts from model.xml
- Fixes for property methods, and couch queries