### PR TITLE
Setup error notification via smtp appender

### DIFF
--- a/assets/config/log4j.xml
+++ b/assets/config/log4j.xml
@@ -41,6 +41,29 @@
         </layout>
     </appender>
     
+    <appender name="gmail" class="org.apache.log4j.net.SMTPAppender">
+        <param name="Bcc" value=""/>
+        <param name="BufferSize" value="512"/>
+        <param name="Cc" value=""/>
+        <param name="LevelMax" value="FATAL"/>
+        <param name="LevelMin" value="ERROR"/>
+        <param name="From" value="opensrpserver@gmail.com"/>
+        <param name="enable" value="true"/>
+        <param name="SMTPDebug" value="TRUE"/>
+        <param name="SMTPHost" value="smtp.gmail.com"/>
+        <param name="SMTPPassword" value="mfblelhwkvtatdpi"/>
+        <param name="SMTPPort" value="465"/>
+        <param name="SMTPProtocol" value="smtps"/>
+        <param name="auth" value="true"/>
+        <param name="SMTPUsername" value="opensrpserver@gmail.com"/>
+        <param name="Subject" value="OpenSRP Server :: Exception Notification :: User ${user.name}"/>
+        <param name="threshold" value="ERROR"/>
+        <param name="To" value="opensrpserver@gmail.com"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{ABSOLUTE} %5p %c{1}:%L - %m%n"/>
+        </layout>
+    </appender>
+    
     <logger name="org.motechproject">
         <level value="WARN"/>
     </logger>
@@ -73,8 +96,9 @@
     
     <root>
         <priority value="INFO"/>
-        <!--<appender-ref ref="RollingLog"/>-->
+        <!-- <appender-ref ref="RollingLog"/> -->
         <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="gmail"/>
     </root>
 
 </log4j:configuration>

--- a/opensrp-connector/src/main/java/org/opensrp/connector/HttpUtil.java
+++ b/opensrp-connector/src/main/java/org/opensrp/connector/HttpUtil.java
@@ -12,6 +12,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.IOUtils;
 import org.opensrp.common.util.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 
@@ -24,6 +26,8 @@ import com.mysql.jdbc.StringUtils;
 @Component
 public class HttpUtil {
 
+	private static Logger logger = LoggerFactory.getLogger(HttpUtil.class.toString());
+	
     public HttpUtil() {
     }
 
@@ -52,6 +56,7 @@ public class HttpUtil {
             return new HttpResponse(con.getResponseCode() == HttpStatus.SC_OK, IOUtils.toString(con.getInputStream()));
 			
         } catch (Exception e) {
+        	logger.error(HttpUtil.class.toString(), e);
             throw new RuntimeException(e);
         }
     }

--- a/opensrp-web/src/main/java/org/opensrp/web/controller/FormSubmissionController.java
+++ b/opensrp-web/src/main/java/org/opensrp/web/controller/FormSubmissionController.java
@@ -138,6 +138,7 @@ public class FormSubmissionController {
 	            		addFormToOpenMRS(formSubmission);
 	            	}
 	            	catch(Exception e){
+	            		logger.error(this.getClass().getName(), e);
 	            		e.printStackTrace();
 	            		ErrorTrace errorTrace=new ErrorTrace(new Date(), "Parse Exception", "", e.getStackTrace().toString(), "Unsolved", formSubmission.formName());
 						errorTrace.setRecordId(formSubmission.instanceId());

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,14 @@
 		</repository>
 	</repositories>
 
+	<dependencies>
+		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>mail</artifactId>
+			<version>1.4</version>
+		</dependency>
+	</dependencies>
+	
 	<build>
 		<!-- <pluginManagement> -->
 			<plugins>


### PR DESCRIPTION
Completed setting up error notification via mail
We are currently forwarding all the mails to opensrp@gmail.com account, which we can configure it to relay the notification to all openers developers, i'll share the password for the account on hip chat.

#Changes:
pom.xml => added mail dependency 
assets/config/log4j.xml => added smtp configs 

The other changes are insignificant e.g just adding logging statement on the catch block so that the error can be sent

NB: all developers should now use longer.error() whenever and error occurs in order to send out the mail notification.