### PR TITLE
Remove blank id requirement

### DIFF
--- a/opensrp-core/src/main/java/org/opensrp/service/OrderService.java
+++ b/opensrp-core/src/main/java/org/opensrp/service/OrderService.java
@@ -20,9 +20,9 @@ public class OrderService {
         // assumes id field is always populated in Order data model object
         // any time an order is created in  couchDB.
         // ASSUMPTION: If an Order comes with an id, then it already exists in CouchDB
-        if (!TextUtils.isEmpty(order.getId())) {
-            throw new IllegalArgumentException("Order object should not have id field populated. " +
-                    "Alternatively, " + order.getId() + " already exists");
+        if (!TextUtils.isEmpty(order.getRevision())) {
+            throw new IllegalArgumentException("Order object should not have revision field populated. " +
+                    "Alternatively, " + order.getRevision() + " already exists");
         }
         order.setDateCreated(new DateTime());
         allOrders.add(order);


### PR DESCRIPTION
The objective of setting a check for the id field was to prevent an attempt to create a new order with the same id as a previously created one, on the server side.

However, we decided that the id should be generated by the Android client so as to uniquely identify an order before posting it to the server. In it's place, the id field is replaced by the revision field as a check for order uniqueness on the server side.